### PR TITLE
ci(release): upgrade npm before publishing for Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,8 +496,13 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
+
+      - name: upgrade npm so Trusted Publishers OIDC handshake works
+        # npm Trusted Publishers needs the OIDC handshake added in
+        # npm ≥ 11.5.1; node 22's bundled npm is older.
+        run: npm install -g npm@latest
 
       - name: publish
         working-directory: packages/schema

--- a/.github/workflows/republish-npm.yml
+++ b/.github/workflows/republish-npm.yml
@@ -1,0 +1,57 @@
+# Manual republish of @idiolect-dev/schema for an existing tag.
+#
+# The tag-triggered release workflow runs the published version of
+# itself (the workflow file at the tagged commit), so a workflow
+# bug discovered after a tag landed cannot be hot-fixed by pushing
+# to main and re-running the failed job. This workflow exists to
+# retarget the npm publish step at an arbitrary tag using whatever
+# release.yml on `main` happens to look like at dispatch time.
+#
+# It uses npm Trusted Publishers (OIDC) the same way release.yml
+# does, but installs `npm@latest` first so the npm CLI is recent
+# enough to drive the OIDC handshake (≥11.5.1, which the runner's
+# default npm is currently older than).
+name: republish-npm
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing tag to republish (e.g. v0.3.0)"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    name: publish @idiolect-dev/schema for ${{ inputs.tag }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.tag }}
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.2"
+
+      - name: install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: typecheck
+        run: bun run typecheck
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: upgrade npm so Trusted Publishers OIDC handshake works
+        run: npm install -g npm@latest
+
+      - name: publish
+        working-directory: packages/schema
+        run: npm publish --provenance --access public


### PR DESCRIPTION
## Summary

The v0.3.0 release tagged this morning published successfully to
crates.io and the GitHub Releases page, but the npm publish step
failed with a 404 from `registry.npmjs.org`. Root cause: npm
Trusted Publishers (OIDC) needs npm CLI ≥ 11.5.1, and node 22's
bundled npm is older. Fix runs \`npm install -g npm@latest\` before
the publish step.

Also adds \`republish-npm.yml\`, a workflow_dispatch entry that
runs against an existing tag — the tag-triggered \`release.yml\`
runs the workflow file at the tagged commit, so a fix on main
does not flow back to an in-progress run. With this in place, the
v0.3.0 npm publish can be replayed by dispatching \`republish-npm\`
with \`tag=v0.3.0\`.

## Change class

- [x] release scaffolding / CI / build

## Testing

CI on this PR exercises the workflow file's syntax and required
checks. The actual fix can only be validated by running
\`republish-npm.yml\` against \`v0.3.0\` once this lands.