### PR TITLE
ci(release): pass --force to npm self-upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -501,8 +501,11 @@ jobs:
 
       - name: upgrade npm so Trusted Publishers OIDC handshake works
         # npm Trusted Publishers needs the OIDC handshake added in
-        # npm ≥ 11.5.1; node 22's bundled npm is older.
-        run: npm install -g npm@latest
+        # npm ≥ 11.5.1; node 22's bundled npm is older. `--force`
+        # skips the self-upgrade dependency-resolution path that,
+        # on the runner image's bundled npm, errors out with
+        # `Cannot find module 'promise-retry'` mid-upgrade.
+        run: npm install -g npm@latest --force
 
       - name: publish
         working-directory: packages/schema

--- a/.github/workflows/republish-npm.yml
+++ b/.github/workflows/republish-npm.yml
@@ -50,7 +50,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: upgrade npm so Trusted Publishers OIDC handshake works
-        run: npm install -g npm@latest
+        # `--force` skips the self-upgrade dependency-resolution
+        # path that, on the runner image's bundled npm, errors out
+        # with `Cannot find module 'promise-retry'` mid-upgrade.
+        run: npm install -g npm@latest --force
 
       - name: publish
         working-directory: packages/schema


### PR DESCRIPTION
Follow-up to #24. The npm self-upgrade in republish-npm.yml errored with `Cannot find module 'promise-retry'` because the bundled npm's partial self-update leaves arborist references that don't match the freshly-installed tree. `--force` skips the offending resolution path and the upgrade completes.