### PR TITLE
ci(release): pin corepack to npm@11.13.0 for Trusted Publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,15 +499,17 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: install a recent npm via corepack
+      - name: install npm 11 via corepack
         # npm Trusted Publishers needs the OIDC handshake added in
         # npm ≥ 11.5.1. The runner image's bundled npm is older
         # AND its tree is missing `promise-retry`, so it can't even
         # self-upgrade. corepack ships a fresh npm tarball into the
-        # path without touching the broken bundled tree.
+        # path; pin a concrete version because `npm@latest` resolves
+        # against corepack's own snapshot (currently 10.x) rather
+        # than the live npm dist-tag.
         run: |
           corepack enable
-          corepack prepare npm@latest --activate
+          corepack prepare npm@11.13.0 --activate
           npm --version
 
       - name: publish

--- a/.github/workflows/republish-npm.yml
+++ b/.github/workflows/republish-npm.yml
@@ -49,15 +49,17 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: install a recent npm via corepack
-        # The runner image's bundled npm is missing
-        # `promise-retry` and can't even invoke `install` to upgrade
-        # itself. corepack ships a fresh npm tarball into the path
-        # without touching the broken bundled tree, which is enough
-        # to give us the Trusted Publishers OIDC handshake (≥11.5.1).
+      - name: install npm 11 via corepack
+        # The runner image's bundled npm is missing `promise-retry`
+        # and can't even invoke `install` to self-upgrade. corepack
+        # ships a fresh npm tarball into the path. We pin a concrete
+        # version: corepack's `npm@latest` resolves against its own
+        # snapshot rather than the live npm dist-tag and currently
+        # returns 10.x, which is below the Trusted Publishers OIDC
+        # handshake floor (≥ 11.5.1).
         run: |
           corepack enable
-          corepack prepare npm@latest --activate
+          corepack prepare npm@11.13.0 --activate
           npm --version
 
       - name: publish


### PR DESCRIPTION
Follow-up to #26. corepack's `npm@latest` returned 10.9.7 — its bundled snapshot lags the live npm dist-tag (11.13.0). Trusted Publishers OIDC was added in npm 11.5.1, so the older corepack pick fails the auth handshake silently and the registry returns 404. Pinning a concrete version solves it.