### PR TITLE
ci(release): run npm from a fetched tarball instead of corepack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -499,22 +499,25 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: install npm 11 via corepack
-        # npm Trusted Publishers needs the OIDC handshake added in
-        # npm ≥ 11.5.1. The runner image's bundled npm is older
-        # AND its tree is missing `promise-retry`, so it can't even
-        # self-upgrade. corepack ships a fresh npm tarball into the
-        # path; pin a concrete version because `npm@latest` resolves
-        # against corepack's own snapshot (currently 10.x) rather
-        # than the live npm dist-tag.
+      - name: fetch a recent npm into a private directory
+        # npm Trusted Publishers' OIDC handshake landed in npm
+        # 11.5.1. The runner image's bundled npm is older AND its
+        # tree is missing `promise-retry` (so it can't even invoke
+        # `install` to upgrade itself), and corepack-managed shims
+        # don't sit ahead of the bundled binary in PATH. The only
+        # reliable path is downloading a fresh npm tarball from the
+        # registry and invoking it directly via `node`.
         run: |
-          corepack enable
-          corepack prepare npm@11.13.0 --activate
-          npm --version
+          mkdir -p "$RUNNER_TEMP/npm-bin"
+          curl -fsSL https://registry.npmjs.org/npm/-/npm-11.13.0.tgz \
+            | tar -xz -C "$RUNNER_TEMP/npm-bin" --strip-components=1
+          node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" --version
 
       - name: publish
         working-directory: packages/schema
-        run: npm publish --provenance --access public
+        run: |
+          node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
+            publish --provenance --access public
 
   # ---------------------------------------------------------------
   # Publish the publishable crates to crates.io in topological

--- a/.github/workflows/republish-npm.yml
+++ b/.github/workflows/republish-npm.yml
@@ -49,19 +49,23 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      - name: install npm 11 via corepack
-        # The runner image's bundled npm is missing `promise-retry`
-        # and can't even invoke `install` to self-upgrade. corepack
-        # ships a fresh npm tarball into the path. We pin a concrete
-        # version: corepack's `npm@latest` resolves against its own
-        # snapshot rather than the live npm dist-tag and currently
-        # returns 10.x, which is below the Trusted Publishers OIDC
-        # handshake floor (≥ 11.5.1).
+      - name: fetch a recent npm into a private directory
+        # The runner image's bundled npm is two issues at once:
+        # its tree is missing `promise-retry` (so it can't run
+        # `install` to upgrade itself even with `--force`), and
+        # corepack-managed npm shims sit behind it in PATH. Trusted
+        # Publishers' OIDC handshake landed in npm 11.5.1, so the
+        # only reliable path is downloading a fresh npm tarball
+        # straight from the registry and invoking it directly via
+        # `node`.
         run: |
-          corepack enable
-          corepack prepare npm@11.13.0 --activate
-          npm --version
+          mkdir -p "$RUNNER_TEMP/npm-bin"
+          curl -fsSL https://registry.npmjs.org/npm/-/npm-11.13.0.tgz \
+            | tar -xz -C "$RUNNER_TEMP/npm-bin" --strip-components=1
+          node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" --version
 
       - name: publish
         working-directory: packages/schema
-        run: npm publish --provenance --access public
+        run: |
+          node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
+            publish --provenance --access public


### PR DESCRIPTION
Follow-up to #27. Pinning corepack didn't help: `corepack prepare npm@11.13.0 --activate` puts shims behind the bundled npm in PATH, so `npm --version` still reports 10.9.7. Fetching the npm tarball directly and invoking via `node bin/npm-cli.js` skips both the broken bundled tree and the PATH ordering issue.