### PR TITLE
ci(release): fall back to NPM_TOKEN when Trusted Publishers isn't configured

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,12 +465,18 @@ jobs:
           generate_release_notes: true
 
   # ---------------------------------------------------------------
-  # Publish @idiolect-dev/schema to npm via Trusted Publishers (OIDC).
-  # No long-lived NPM_TOKEN — npm is configured at
-  # npmjs.com/package/@idiolect-dev/schema/access to trust this
-  # repo + workflow filename, and the npm CLI exchanges the job's
-  # OIDC token for short-lived publish credentials automatically
-  # when `--provenance` is set.
+  # Publish @idiolect-dev/schema to npm. Two auth modes:
+  #
+  # - If `NPM_TOKEN` is set as a repo secret, publish with classic
+  #   token auth (no provenance attestation).
+  # - Otherwise, publish via Trusted Publishers (OIDC + provenance);
+  #   this requires npmjs.com/package/<name>/access to allowlist
+  #   this repo + workflow filename.
+  #
+  # Trusted Publishers is preferred when configured because the
+  # publish artifact carries a sigstore-signed attestation linking
+  # back to this run. Token publishing is the fallback so a release
+  # can ship while the package owner sets up the allowlist.
   # ---------------------------------------------------------------
   publish-npm:
     name: publish @idiolect-dev/schema
@@ -515,9 +521,18 @@ jobs:
 
       - name: publish
         working-directory: packages/schema
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
-            publish --provenance --access public
+          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::notice::publishing with NPM_TOKEN (no provenance)"
+            node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
+              publish --access public
+          else
+            echo "::notice::no NPM_TOKEN; publishing via Trusted Publishers OIDC"
+            node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
+              publish --provenance --access public
+          fi
 
   # ---------------------------------------------------------------
   # Publish the publishable crates to crates.io in topological

--- a/.github/workflows/republish-npm.yml
+++ b/.github/workflows/republish-npm.yml
@@ -7,10 +7,17 @@
 # retarget the npm publish step at an arbitrary tag using whatever
 # release.yml on `main` happens to look like at dispatch time.
 #
-# It uses npm Trusted Publishers (OIDC) the same way release.yml
-# does, but installs `npm@latest` first so the npm CLI is recent
-# enough to drive the OIDC handshake (≥11.5.1, which the runner's
-# default npm is currently older than).
+# Two auth modes are supported:
+#
+# - If `NPM_TOKEN` is set as a repo secret, publish with classic
+#   token auth (no provenance attestation).
+# - Otherwise, publish via Trusted Publishers (OIDC + provenance).
+#   This requires npmjs.com/package/<name>/access to allowlist
+#   this repo + workflow filename.
+#
+# Either way, the bundled npm CLI on the runner image is too old
+# for the Trusted Publishers OIDC handshake (≥ 11.5.1) and is
+# missing `promise-retry`, so we fetch a fresh tarball first.
 name: republish-npm
 
 on:
@@ -66,6 +73,15 @@ jobs:
 
       - name: publish
         working-directory: packages/schema
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
-            publish --provenance --access public
+          if [ -n "${NODE_AUTH_TOKEN:-}" ]; then
+            echo "::notice::publishing with NPM_TOKEN (no provenance)"
+            node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
+              publish --access public
+          else
+            echo "::notice::no NPM_TOKEN; publishing via Trusted Publishers OIDC"
+            node "$RUNNER_TEMP/npm-bin/bin/npm-cli.js" \
+              publish --provenance --access public
+          fi


### PR DESCRIPTION
Follow-up to #28. The bundled-npm and corepack issues are fixed (npm 11.13.0 is now invoked successfully via the fetched tarball), but the publish still 404s because npm 11's clearer error message (`do not have permission to access`) reveals the npmjs.com Trusted Publishers allowlist for @idiolect-dev/schema does not include this repo + workflow yet. The 0.2.0 release shipped via classic NPM_TOKEN, which is still configured. This PR branches the publish step on whether the secret is present so the release ships while the allowlist is set up.