### PR TITLE
ci(release): bun run build before npm publish (v0.4.1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -494,6 +494,18 @@ jobs:
       - name: typecheck
         run: bun run typecheck
 
+      - name: build dist/
+        # `package.json` declares `"main": "./dist/index.js"` and
+        # `"files": ["dist", "src", ...]`, so the publish must include
+        # the built dist/ tree. The `bun run build` script wipes
+        # dist/ and rebuilds the bundled `.js` plus tsc-emitted `.d.ts`
+        # — without this step npm publish ships only `src/` and
+        # consumers see "Cannot find module @idiolect-dev/schema".
+        # (v0.4.0 shipped without dist/ for exactly this reason; the
+        # earlier v0.3.0 publish was driven manually from a developer
+        # machine where the build step was implicit.)
+        run: bun run build
+
       - uses: actions/setup-node@v4
         with:
           node-version: "22"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,22 @@ subsection under `[Unreleased]`, and the release cut moves these
 lines into the new versioned section.
 -->
 
+## [0.4.1] — 2026-04-26
+
+### Fixed
+
+- The release pipeline's `publish-npm` job now runs `bun run build`
+  before `npm publish`, so the published `@idiolect-dev/schema`
+  tarball includes the compiled `dist/` tree the package's
+  `"main"` / `"types"` / `"exports"` entries point at. v0.4.0
+  shipped without `dist/` (only `src/` and a stale
+  `dist/.tsbuildinfo` from the typecheck step) — consumers
+  importing from `@idiolect-dev/schema` saw "Cannot find module"
+  at typecheck time. The earlier v0.3.0 publish was driven from a
+  developer machine where the build step ran implicitly; v0.4.0
+  was the first fully-CI-driven release and exposed the missing
+  step. Republish via the v0.4.1 tag picks up the fix.
+
 ## [0.4.0] — 2026-04-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "serde",
  "serde_json",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.4.0", path = "../idiolect-records" }
-idiolect-identity = { version = "0.4.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.4.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-records  = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-identity = { version = "0.4.1", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.4.1", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.4.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.4.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.4.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.4.0", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.4.1", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.4.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.4.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.4.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.4.0", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.4.0", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.4.1", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.4.0", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.4.1", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.4.0", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.4.0", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.4.1", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.4.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.4.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.4.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",


### PR DESCRIPTION
## Summary

Fix the npm publish step in the release workflow. The `publish-npm` job ran `bun install` + `bun run typecheck` + `npm publish` but never invoked `bun run build`. Since `packages/schema/package.json`'s `\"main\"`, `\"types\"`, and `\"exports\"` all point at `./dist/`, the v0.4.0 tarball shipped without the compiled tree — anyone importing `@idiolect-dev/schema` saw \"Cannot find module\" on typecheck. v0.3.0 was published from a developer machine where the build step ran implicitly; v0.4.0 was the first fully-CI-driven release and exposed the gap.

Adds a `bun run build` step between typecheck and publish, bumps to v0.4.1, and CHANGELOG-notes the fix.

## Change class

- [x] bug fix
- [ ] feature (non-breaking)
- [ ] refactor (no behavior change)
- [ ] documentation only
- [x] release scaffolding / CI / build
- [ ] schema change (lexicon edit — will be classified by check-compat)

## Testing

- `cd packages/schema && bun run build` — succeeds, emits `dist/index.js` (14.79 KB) plus `.d.ts`, `.d.ts.map`, and the per-module subtree.
- `cargo build --workspace --all-features` — passes against the bumped versions.
- `cargo test --workspace` — green.

The publish path itself can only be exercised end-to-end at tag time; v0.4.1 will tag once this lands and the resulting tarball gets inspected before any further release.

## Architecture notes

The build script (`packages/schema/scripts/build.ts`) wipes `dist/` before rebuilding, so there's no stale-artifact risk from running typecheck first (the typecheck step writes only `.tsbuildinfo` because `composite: true` requires a build-info file even under `--noEmit`).

The `republish-npm.yml` workflow was deleted in #29; if we want a manual escape hatch for re-publishing an existing tag with this fix, it should come back as a separate PR.