### PR TITLE
ci(release): ship lexicons/ in @idiolect-dev/schema tarball (v0.4.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,9 @@ notes/
 
 # claude code runtime state
 .claude/
+
+# Build artefact: packages/schema/scripts/build.ts copies the
+# workspace-root lexicons/ tree here so loadLexiconDocs resolves
+# it via import.meta.url-relative paths in both dev and published
+# builds. The workspace root is the source of truth.
+packages/schema/lexicons/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,21 @@ subsection under `[Unreleased]`, and the release cut moves these
 lines into the new versioned section.
 -->
 
+## [0.4.2] — 2026-04-26
+
+### Fixed
+
+- `@idiolect-dev/schema`'s build now copies the workspace-root
+  `lexicons/` tree into `packages/schema/lexicons/` before
+  publish, so the directory the package's `files` array claims
+  is actually included in the npm tarball. Previously the path
+  was workspace-relative-only — `loadLexiconDocs()` worked from
+  the source repo but threw `ENOENT` for any consumer importing
+  `@idiolect-dev/schema` from `node_modules/`. Also retargets
+  `LEXICONS_DIR` to `../lexicons` (sibling of `dist/`) so the
+  same path resolves cleanly in dev (off `src/`) and after
+  publish (off `dist/`).
+
 ## [0.4.1] — 2026-04-26
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "serde",
  "serde_json",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.4.1", path = "../idiolect-records" }
-idiolect-identity = { version = "0.4.1", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.4.1", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-records  = { version = "0.4.2", path = "../idiolect-records" }
+idiolect-identity = { version = "0.4.2", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.4.2", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-records = { version = "0.4.2", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-records = { version = "0.4.2", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
+idiolect-records = { version = "0.4.2", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.4.1", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.4.2", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.4.1", path = "../idiolect-lens" }
+idiolect-records = { version = "0.4.2", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.4.2", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.4.1", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.4.2", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.4.2", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.4.1", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.4.2", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.4.1", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.4.1", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.4.2", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.4.2", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.4.1", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.4.1", path = "../idiolect-lens" }
+idiolect-records = { version = "0.4.2", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.4.2", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -37,7 +37,9 @@
     "generate": "cargo run --quiet --manifest-path ../../Cargo.toml -p idiolect-codegen",
     "generate:check": "cargo run --quiet --manifest-path ../../Cargo.toml -p idiolect-codegen -- --check",
     "build": "bun run scripts/build.ts",
+    "copy-lexicons": "bun run scripts/copy-lexicons.ts",
     "typecheck": "tsc --noEmit",
+    "pretest": "bun run scripts/copy-lexicons.ts",
     "test": "bun test",
     "lint": "biome check src tests scripts"
   },

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",

--- a/packages/schema/scripts/build.ts
+++ b/packages/schema/scripts/build.ts
@@ -6,26 +6,29 @@
 // .d.ts files (as of bun 1.2), so the two-step split is deliberate.
 
 import { spawnSync } from "node:child_process";
-import { cpSync, mkdirSync, rmSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = fileURLToPath(new URL(".", import.meta.url));
 const ROOT = resolve(HERE, "..");
 const DIST = resolve(ROOT, "dist");
-const WORKSPACE_LEXICONS = resolve(ROOT, "..", "..", "lexicons");
-const LOCAL_LEXICONS = resolve(ROOT, "lexicons");
 
 rmSync(DIST, { recursive: true, force: true });
 mkdirSync(DIST, { recursive: true });
 
-// Copy the workspace-root lexicons/ tree into the package
-// directory so it ships with the tarball and so `loadLexiconDocs`
+// Stage lexicons/ alongside the package so loadLexiconDocs
 // resolves it via `import.meta.url`-relative paths in both dev
-// and published builds. The directory is gitignored — the
-// workspace root is the source of truth.
-rmSync(LOCAL_LEXICONS, { recursive: true, force: true });
-cpSync(WORKSPACE_LEXICONS, LOCAL_LEXICONS, { recursive: true });
+// and published builds. Delegates to scripts/copy-lexicons.ts so
+// the same copy runs as a `pretest` hook for tests that exercise
+// loadLexiconDocs without a full bundle.
+{
+  const result = spawnSync("bun", ["run", "scripts/copy-lexicons.ts"], {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+  if (result.status !== 0) process.exit(result.status ?? 1);
+}
 
 // step 1: bun-bundle js from src/index.ts.
 const bundle = spawnSync(

--- a/packages/schema/scripts/build.ts
+++ b/packages/schema/scripts/build.ts
@@ -6,16 +6,26 @@
 // .d.ts files (as of bun 1.2), so the two-step split is deliberate.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync, rmSync } from "node:fs";
+import { cpSync, mkdirSync, rmSync } from "node:fs";
 import { resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const HERE = fileURLToPath(new URL(".", import.meta.url));
 const ROOT = resolve(HERE, "..");
 const DIST = resolve(ROOT, "dist");
+const WORKSPACE_LEXICONS = resolve(ROOT, "..", "..", "lexicons");
+const LOCAL_LEXICONS = resolve(ROOT, "lexicons");
 
 rmSync(DIST, { recursive: true, force: true });
 mkdirSync(DIST, { recursive: true });
+
+// Copy the workspace-root lexicons/ tree into the package
+// directory so it ships with the tarball and so `loadLexiconDocs`
+// resolves it via `import.meta.url`-relative paths in both dev
+// and published builds. The directory is gitignored — the
+// workspace root is the source of truth.
+rmSync(LOCAL_LEXICONS, { recursive: true, force: true });
+cpSync(WORKSPACE_LEXICONS, LOCAL_LEXICONS, { recursive: true });
 
 // step 1: bun-bundle js from src/index.ts.
 const bundle = spawnSync(

--- a/packages/schema/scripts/copy-lexicons.ts
+++ b/packages/schema/scripts/copy-lexicons.ts
@@ -1,0 +1,23 @@
+#!/usr/bin/env bun
+// Copy the workspace-root lexicons/ tree into packages/schema/lexicons/
+// so the package directory has a local copy at the path
+// `loadLexiconDocs` resolves via `import.meta.url`-relative paths.
+//
+// Idempotent: clears the destination first so a stale lexicon left
+// over from a prior cut doesn't survive a removal upstream.
+//
+// Used both by `bun run build` (full publish path) and by
+// `bun run pretest` (so `bun test` works against `src/` without
+// having to run a full bundle first).
+
+import { cpSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = fileURLToPath(new URL(".", import.meta.url));
+const ROOT = resolve(HERE, "..");
+const WORKSPACE_LEXICONS = resolve(ROOT, "..", "..", "lexicons");
+const LOCAL_LEXICONS = resolve(ROOT, "lexicons");
+
+rmSync(LOCAL_LEXICONS, { recursive: true, force: true });
+cpSync(WORKSPACE_LEXICONS, LOCAL_LEXICONS, { recursive: true });

--- a/packages/schema/src/lexicons.ts
+++ b/packages/schema/src/lexicons.ts
@@ -4,10 +4,22 @@ import { fileURLToPath } from "node:url";
 import { type LexiconDoc, Lexicons } from "@atproto/lexicon";
 
 // resolve the lexicons/ directory relative to this module.
-// the package ships the raw json so consumers can rebuild the lexicons
-// instance with their own extensions without re-fetching.
+//
+// The package ships the raw json so consumers can rebuild the
+// lexicons instance with their own extensions without re-fetching.
+// Build-time `scripts/build.ts` copies the workspace-root
+// `lexicons/` tree into `packages/schema/lexicons/` so the path
+// math is the same in dev (running off `src/`) and after publish
+// (running off `dist/`):
+//
+//   - dev:       src/lexicons.ts → ../lexicons → packages/schema/lexicons/
+//   - published: dist/index.js   → ../lexicons → package/lexicons/
+//
+// `..` from the bundled `dist/index.js` resolves to the package
+// root because `import.meta.url` points at the bundled file's
+// location, not at the original source path.
 const HERE = fileURLToPath(new URL(".", import.meta.url));
-const LEXICONS_DIR = join(HERE, "..", "..", "..", "lexicons");
+const LEXICONS_DIR = join(HERE, "..", "lexicons");
 
 /**
  * Recursively enumerate every .json file under `root`.


### PR DESCRIPTION
## Summary

`packages/schema/package.json` declared `files: [\"dist\", \"src\", \"lexicons\", ...]` but `packages/schema/lexicons/` doesn't exist — npm silently drops missing path entries, so the v0.4.0 / v0.4.1 tarballs both shipped without lexicon JSON. `loadLexiconDocs()` resolved its default path as `../../../lexicons` (workspace root) which works from the source checkout but throws ENOENT for any consumer importing the package out of `node_modules/`. Fieldwork worked around this by vendoring the lexicons directly from upstream; this PR fixes the upstream cause.

Two-part fix:

- `packages/schema/scripts/build.ts` copies the workspace-root `lexicons/` tree into `packages/schema/lexicons/` before bundle + tsc.
- `src/lexicons.ts` retargets `LEXICONS_DIR` from `../../../lexicons` (workspace-only) to `../lexicons` (sibling of `dist/`), so the same path resolves in dev (off `src/`) and after publish (off `dist/`).

`packages/schema/lexicons/` is added to `.gitignore` — the workspace root is the source of truth.

## Change class

- [x] bug fix
- [ ] feature (non-breaking)
- [ ] refactor (no behavior change)
- [ ] documentation only
- [x] release scaffolding / CI / build
- [ ] schema change

## Testing

- `bun run --cwd packages/schema build` — succeeds, `packages/schema/lexicons/` populated with 55 lexicon JSON files.
- `bun run --cwd packages/schema test` — 19 tests pass.
- `npm pack --dry-run` from `packages/schema/` — 56 lexicon paths in the proposed tarball (was 0 in v0.4.1).
- `cargo build --workspace` — passes against the bumped versions.
- `cargo test --workspace` — green.

## Architecture notes

The path-math invariant we want is that `loadLexiconDocs()` works from both source and published builds with the same constant. After this fix, the layout is:

```
dev:        src/lexicons.ts → ../lexicons → packages/schema/lexicons/
published:  dist/index.js   → ../lexicons → package/lexicons/
```

Both resolve via `import.meta.url`-relative paths because `import.meta.url` points at the bundled file's location, not at the original source path.