### PR TITLE
fix(codegen): family.rs reaches per-record types through full module path (closes #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ if you depend on this project, and read this file before bumping.
 
 ### Security
 
+## [0.6.1] — 2026-04-28
+
+### Fixed
+
+- `idiolect-codegen`'s family emitter named `AnyRecord` variants and `crate::<TypeName>` paths from the unqualified record type, while `mod.rs`'s walk-up disambiguation aliased colliding leaf names. Two records sharing a leaf TypeName produced duplicate enum variants and dangling `crate::<TypeName>` references that the crate-root re-export never declared. The family emitter now reuses the same disambiguation pass and reaches per-record types through their full `crate::generated::<…>::<TypeName>` path with a local `use … as <UniqueIdent>` binding, so families with cross-prefix leaf-name collisions (e.g. `pub.layers.changelog.entry::Entry` vs `pub.layers.resource.entry::Entry`) emit unique variants and compile. Closes #44.
+
 ## [0.6.0] — 2026-04-28
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "cid",
  "language-tags",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.6.0", path = "../idiolect-records" }
-idiolect-identity = { version = "0.6.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.6.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-records  = { version = "0.6.1", path = "../idiolect-records" }
+idiolect-identity = { version = "0.6.1", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.6.1", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-codegen/src/emit/family.rs
+++ b/crates/idiolect-codegen/src/emit/family.rs
@@ -20,7 +20,7 @@ use quote::{format_ident, quote};
 
 use crate::lexicon::{Def, LexiconDoc, module_name_for_nsid};
 
-use super::rust::pascal_case;
+use super::rust::{pascal_case, rust_module_path, walk_up_aliases};
 
 /// Configuration for a single family.
 ///
@@ -71,9 +71,20 @@ pub fn idiolect_family() -> FamilyConfig {
 /// emitter splices into the generated module.
 struct Entry {
     nsid: String,
+    /// Variant ident for the `AnyRecord` enum and local alias the
+    /// imported type is bound to. Disambiguated by
+    /// [`walk_up_aliases`] when two records share a leaf type name,
+    /// so each variant is unique within the enum.
     ident: syn::Ident,
+    /// Type path for `AnyRecord`'s variant body. After the use
+    /// statement binds the disambiguated alias, this is just `ident`.
     ty: syn::Type,
+    /// Path to the per-record module's `NSID` const, routed through
+    /// the disambiguated alias.
     nsid_path: syn::Path,
+    /// `use crate::generated::<…>::<raw_ty> as <ident>;` token
+    /// stream spliced at the top of the rendered file.
+    import: TokenStream,
 }
 
 /// Render the body of `generated/family.rs`.
@@ -151,6 +162,8 @@ pub fn render_family_rs(docs: &[LexiconDoc], cfg: &FamilyConfig) -> Result<Strin
         " Marker type for the `{id_lit}` family. Implementing\n [`RecordFamily`] makes the family first-class alongside any\n downstream-curated family or composed [`OrFamily`](crate::OrFamily).",
     );
 
+    let record_imports = entries.iter().map(|e| e.import.clone());
+
     let output: TokenStream = quote! {
         #![allow(clippy::large_enum_variant)]
 
@@ -159,6 +172,12 @@ pub fn render_family_rs(docs: &[LexiconDoc], cfg: &FamilyConfig) -> Result<Strin
         use crate::family::RecordFamily;
         use crate::record::DecodeError;
         use serde::{Serialize, Serializer};
+
+        // Per-record types reached through their full
+        // `crate::generated::…` path, bound to a disambiguated
+        // local alias. Aliases share `mod.rs`'s walk-up logic so
+        // colliding leaf names get unique idents.
+        #(#record_imports)*
 
         #[doc = #marker_doc]
         #[derive(Debug, Clone, Copy)]
@@ -336,22 +355,61 @@ pub fn render_family_rs(docs: &[LexiconDoc], cfg: &FamilyConfig) -> Result<Strin
 }
 
 fn collect_entries(docs: &[LexiconDoc], cfg: &FamilyConfig) -> Vec<Entry> {
-    docs.iter()
+    let mut members: Vec<&LexiconDoc> = docs
+        .iter()
         .filter(|d| matches!(d.defs.get("main"), Some(Def::Record(_))))
         .filter(|d| d.nsid.starts_with(cfg.nsid_prefix.as_ref()))
-        .map(|doc| {
-            let module = module_name_for_nsid(&doc.nsid);
-            let ty_name = pascal_case(&module);
-            let ident = format_ident!("{}", ty_name);
+        .collect();
+    // Stable order so the disambiguator's output, the use statements,
+    // and the AnyRecord variants all align.
+    members.sort_by(|a, b| a.nsid.cmp(&b.nsid));
+
+    let prepared: Vec<(Vec<String>, String)> = members
+        .iter()
+        .map(|d| {
+            (
+                rust_module_path(&d.nsid),
+                pascal_case(&module_name_for_nsid(&d.nsid)),
+            )
+        })
+        .collect();
+    let aliases = walk_up_aliases(&prepared);
+
+    members
+        .into_iter()
+        .enumerate()
+        .map(|(i, doc)| {
+            let (path_segments, raw_ty_name) = &prepared[i];
+            // Disambiguated alias when the leaf TypeName collides
+            // with another in the family, raw PascalCase leaf
+            // otherwise.
+            let ident_name = aliases[i].clone().unwrap_or_else(|| raw_ty_name.clone());
+            let ident = format_ident!("{}", ident_name);
+
+            // Full path through the generated tree, e.g.
+            // `crate::generated::r#pub::layers::changelog::entry`.
+            let raw_ident = format_ident!("{}", raw_ty_name);
+            let joined = path_segments.join("::");
+            let module_path: syn::Path = syn::parse_str(&format!("crate::generated::{joined}"))
+                .expect("generated module path parses");
+
+            // Bind the disambiguated alias locally so every
+            // downstream reference resolves through one ident.
+            let import = quote! {
+                use #module_path::#raw_ident as #ident;
+            };
+
             let ty: syn::Type =
-                syn::parse_str(&format!("crate::{ty_name}")).expect("generated type path parses");
-            let nsid_path: syn::Path = syn::parse_str(&format!("crate::{ty_name}::NSID"))
-                .expect("generated NSID path parses");
+                syn::parse_str(&ident_name).expect("alias ident parses as a type path");
+            let nsid_path: syn::Path =
+                syn::parse_str(&format!("{ident_name}::NSID")).expect("alias::NSID path parses");
+
             Entry {
                 nsid: doc.nsid.clone(),
                 ident,
                 ty,
                 nsid_path,
+                import,
             }
         })
         .collect()

--- a/crates/idiolect-codegen/src/emit/rust.rs
+++ b/crates/idiolect-codegen/src/emit/rust.rs
@@ -640,7 +640,11 @@ fn render_mod_rs(docs: &[LexiconDoc]) -> String {
     out
 }
 
-fn rust_module_path(nsid: &str) -> Vec<String> {
+/// `module_path_for_nsid` segments with raw-identifier escaping
+/// applied to any segment that collides with a Rust keyword (`pub`,
+/// `mod`, etc.). Used by every emitter that needs a fully-qualified
+/// `crate::generated::<…>` path to a per-record module.
+pub(super) fn rust_module_path(nsid: &str) -> Vec<String> {
     module_path_for_nsid(nsid)
         .into_iter()
         .map(|s| {
@@ -657,7 +661,7 @@ fn rust_module_path(nsid: &str) -> Vec<String> {
 ///
 /// `aliases[i]` is `Some(prefix + ty)` when `type_name` `i` collides
 /// with another in the slice; `None` when its leaf is unique.
-fn walk_up_aliases(prepared: &[(Vec<String>, String)]) -> Vec<Option<String>> {
+pub(super) fn walk_up_aliases(prepared: &[(Vec<String>, String)]) -> Vec<Option<String>> {
     use std::collections::BTreeMap;
 
     let mut by_ty: BTreeMap<&str, Vec<usize>> = BTreeMap::new();

--- a/crates/idiolect-codegen/tests/layers_family.rs
+++ b/crates/idiolect-codegen/tests/layers_family.rs
@@ -143,12 +143,53 @@ fn emit_rust_picks_up_non_idiolect_family() {
     );
 
     // Sanity: prettyplease still parses what we emitted as valid Rust.
-    let _ = syn::parse_file(&family_rs.contents).unwrap_or_else(|e| {
+    let parsed = syn::parse_file(&family_rs.contents).unwrap_or_else(|e| {
         panic!(
             "rendered family.rs should parse as Rust:\n{}\n\nerror: {e}",
             family_rs.contents
         )
     });
+
+    // Cross-prefix leaf-name collisions (`pub.layers.changelog.entry`
+    // and `pub.layers.resource.entry` both expose `Entry`) must
+    // disambiguate to unique variant idents in the `AnyRecord` enum.
+    let any_record_variants = collect_any_record_variants(&parsed)
+        .expect("AnyRecord enum is present in rendered family.rs");
+    let unique_variants: std::collections::BTreeSet<&String> = any_record_variants.iter().collect();
+    assert_eq!(
+        unique_variants.len(),
+        any_record_variants.len(),
+        "AnyRecord variants must be pairwise unique; got:\n{any_record_variants:?}"
+    );
+
+    for expected in ["ChangelogEntry", "ResourceEntry"] {
+        assert!(
+            any_record_variants.iter().any(|v| v == expected),
+            "AnyRecord should contain disambiguated variant `{expected}`; got:\n{any_record_variants:?}",
+        );
+    }
+
+    // Per-record types must reach through their full
+    // `crate::generated::…` path, not the crate-root re-export
+    // shortcut (which mod.rs aliases on collision and so doesn't
+    // expose under the unqualified leaf name).
+    assert!(
+        !family_rs.contents.contains("crate::Entry"),
+        "family.rs uses an unqualified `crate::Entry`; got:\n{}",
+        family_rs.contents,
+    );
+}
+
+/// Collect the variant identifiers of the `pub enum AnyRecord { ... }`
+/// item in a parsed family.rs file. Returns `None` if no such enum is
+/// present.
+fn collect_any_record_variants(file: &syn::File) -> Option<Vec<String>> {
+    file.items.iter().find_map(|item| match item {
+        syn::Item::Enum(e) if e.ident == "AnyRecord" => {
+            Some(e.variants.iter().map(|v| v.ident.to_string()).collect())
+        }
+        _ => None,
+    })
 }
 
 #[test]

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.6.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.6.1", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.6.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.6.1", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.6.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.6.1", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.6.0", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.6.1", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.6.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.6.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.6.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.6.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.6.0", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.6.0", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.6.1", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.6.1", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.6.0", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.6.1", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.6.0", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.6.0", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.6.1", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.6.1", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-records/src/generated/family.rs
+++ b/crates/idiolect-records/src/generated/family.rs
@@ -12,6 +12,18 @@
 use crate::Nsid;
 use crate::Record;
 use crate::family::RecordFamily;
+use crate::generated::dev::idiolect::adapter::Adapter;
+use crate::generated::dev::idiolect::belief::Belief;
+use crate::generated::dev::idiolect::bounty::Bounty;
+use crate::generated::dev::idiolect::community::Community;
+use crate::generated::dev::idiolect::correction::Correction;
+use crate::generated::dev::idiolect::dialect::Dialect;
+use crate::generated::dev::idiolect::encounter::Encounter;
+use crate::generated::dev::idiolect::observation::Observation;
+use crate::generated::dev::idiolect::recommendation::Recommendation;
+use crate::generated::dev::idiolect::retrospection::Retrospection;
+use crate::generated::dev::idiolect::verification::Verification;
+use crate::generated::dev::idiolect::vocab::Vocab;
 use crate::record::DecodeError;
 use serde::{Serialize, Serializer};
 /** Marker type for the `dev.idiolect` family. Implementing
@@ -26,47 +38,47 @@ pub struct IdiolectFamily;
 #[derive(Debug, Clone)]
 pub enum AnyRecord {
     /// A `dev.idiolect.adapter` record.
-    Adapter(crate::Adapter),
+    Adapter(Adapter),
     /// A `dev.idiolect.belief` record.
-    Belief(crate::Belief),
+    Belief(Belief),
     /// A `dev.idiolect.bounty` record.
-    Bounty(crate::Bounty),
+    Bounty(Bounty),
     /// A `dev.idiolect.community` record.
-    Community(crate::Community),
+    Community(Community),
     /// A `dev.idiolect.correction` record.
-    Correction(crate::Correction),
+    Correction(Correction),
     /// A `dev.idiolect.dialect` record.
-    Dialect(crate::Dialect),
+    Dialect(Dialect),
     /// A `dev.idiolect.encounter` record.
-    Encounter(crate::Encounter),
+    Encounter(Encounter),
     /// A `dev.idiolect.observation` record.
-    Observation(crate::Observation),
+    Observation(Observation),
     /// A `dev.idiolect.recommendation` record.
-    Recommendation(crate::Recommendation),
+    Recommendation(Recommendation),
     /// A `dev.idiolect.retrospection` record.
-    Retrospection(crate::Retrospection),
+    Retrospection(Retrospection),
     /// A `dev.idiolect.verification` record.
-    Verification(crate::Verification),
+    Verification(Verification),
     /// A `dev.idiolect.vocab` record.
-    Vocab(crate::Vocab),
+    Vocab(Vocab),
 }
 impl AnyRecord {
     /// Canonical NSID string of the contained record.
     #[must_use]
     pub const fn nsid_str(&self) -> &'static str {
         match self {
-            Self::Adapter(_) => crate::Adapter::NSID,
-            Self::Belief(_) => crate::Belief::NSID,
-            Self::Bounty(_) => crate::Bounty::NSID,
-            Self::Community(_) => crate::Community::NSID,
-            Self::Correction(_) => crate::Correction::NSID,
-            Self::Dialect(_) => crate::Dialect::NSID,
-            Self::Encounter(_) => crate::Encounter::NSID,
-            Self::Observation(_) => crate::Observation::NSID,
-            Self::Recommendation(_) => crate::Recommendation::NSID,
-            Self::Retrospection(_) => crate::Retrospection::NSID,
-            Self::Verification(_) => crate::Verification::NSID,
-            Self::Vocab(_) => crate::Vocab::NSID,
+            Self::Adapter(_) => Adapter::NSID,
+            Self::Belief(_) => Belief::NSID,
+            Self::Bounty(_) => Bounty::NSID,
+            Self::Community(_) => Community::NSID,
+            Self::Correction(_) => Correction::NSID,
+            Self::Dialect(_) => Dialect::NSID,
+            Self::Encounter(_) => Encounter::NSID,
+            Self::Observation(_) => Observation::NSID,
+            Self::Recommendation(_) => Recommendation::NSID,
+            Self::Retrospection(_) => Retrospection::NSID,
+            Self::Verification(_) => Verification::NSID,
+            Self::Vocab(_) => Vocab::NSID,
         }
     }
     /// Typed NSID of the contained record. Parses
@@ -171,18 +183,18 @@ pub fn decode_record(nsid: &Nsid, value: serde_json::Value) -> Result<AnyRecord,
     }
     let s = nsid.as_str();
     match s {
-        s if s == crate::Adapter::NSID => Ok(AnyRecord::Adapter(from(value)?)),
-        s if s == crate::Belief::NSID => Ok(AnyRecord::Belief(from(value)?)),
-        s if s == crate::Bounty::NSID => Ok(AnyRecord::Bounty(from(value)?)),
-        s if s == crate::Community::NSID => Ok(AnyRecord::Community(from(value)?)),
-        s if s == crate::Correction::NSID => Ok(AnyRecord::Correction(from(value)?)),
-        s if s == crate::Dialect::NSID => Ok(AnyRecord::Dialect(from(value)?)),
-        s if s == crate::Encounter::NSID => Ok(AnyRecord::Encounter(from(value)?)),
-        s if s == crate::Observation::NSID => Ok(AnyRecord::Observation(from(value)?)),
-        s if s == crate::Recommendation::NSID => Ok(AnyRecord::Recommendation(from(value)?)),
-        s if s == crate::Retrospection::NSID => Ok(AnyRecord::Retrospection(from(value)?)),
-        s if s == crate::Verification::NSID => Ok(AnyRecord::Verification(from(value)?)),
-        s if s == crate::Vocab::NSID => Ok(AnyRecord::Vocab(from(value)?)),
+        s if s == Adapter::NSID => Ok(AnyRecord::Adapter(from(value)?)),
+        s if s == Belief::NSID => Ok(AnyRecord::Belief(from(value)?)),
+        s if s == Bounty::NSID => Ok(AnyRecord::Bounty(from(value)?)),
+        s if s == Community::NSID => Ok(AnyRecord::Community(from(value)?)),
+        s if s == Correction::NSID => Ok(AnyRecord::Correction(from(value)?)),
+        s if s == Dialect::NSID => Ok(AnyRecord::Dialect(from(value)?)),
+        s if s == Encounter::NSID => Ok(AnyRecord::Encounter(from(value)?)),
+        s if s == Observation::NSID => Ok(AnyRecord::Observation(from(value)?)),
+        s if s == Recommendation::NSID => Ok(AnyRecord::Recommendation(from(value)?)),
+        s if s == Retrospection::NSID => Ok(AnyRecord::Retrospection(from(value)?)),
+        s if s == Verification::NSID => Ok(AnyRecord::Verification(from(value)?)),
+        s if s == Vocab::NSID => Ok(AnyRecord::Vocab(from(value)?)),
         other => Err(DecodeError::UnknownNsid(other.to_owned())),
     }
 }
@@ -192,18 +204,18 @@ impl RecordFamily for IdiolectFamily {
     fn contains(nsid: &Nsid) -> bool {
         matches!(
             nsid.as_str(),
-            crate::Adapter::NSID
-                | crate::Belief::NSID
-                | crate::Bounty::NSID
-                | crate::Community::NSID
-                | crate::Correction::NSID
-                | crate::Dialect::NSID
-                | crate::Encounter::NSID
-                | crate::Observation::NSID
-                | crate::Recommendation::NSID
-                | crate::Retrospection::NSID
-                | crate::Verification::NSID
-                | crate::Vocab::NSID
+            Adapter::NSID
+                | Belief::NSID
+                | Bounty::NSID
+                | Community::NSID
+                | Correction::NSID
+                | Dialect::NSID
+                | Encounter::NSID
+                | Observation::NSID
+                | Recommendation::NSID
+                | Retrospection::NSID
+                | Verification::NSID
+                | Vocab::NSID
         )
     }
     fn decode(

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.6.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.6.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.6.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.6.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",


### PR DESCRIPTION
<!-- Closes #44. Builds on #41's FamilyConfig plumbing. -->

## Summary

`idiolect-codegen`'s family emitter named `AnyRecord` variants and `crate::<TypeName>` paths from the unqualified record type, but `mod.rs`'s walk-up disambiguation aliases colliding leaf names. A family with two records sharing a leaf TypeName (e.g. `pub.layers.changelog.entry::Entry` and `pub.layers.resource.entry::Entry`) produced duplicate enum variants and dangling `crate::<TypeName>` references that the crate-root re-export never declared — the file parsed but didn't compile. The family emitter now reuses `mod.rs`'s disambiguation pass and reaches per-record types through the full `crate::generated::<…>::<TypeName>` path bound to a unique local alias.

## Change class

- [x] bug fix
- [ ] feature (non-breaking)
- [ ] refactor (no behavior change)
- [ ] documentation only
- [x] release scaffolding / CI / build
- [ ] schema change (lexicon edit — will be classified by check-compat)

(The release scaffolding tick covers the 0.6.0 → 0.6.1 patch bump.)

## Testing

Locally:

- `cargo build --workspace --all-features` clean.
- `cargo run -p idiolect-codegen -- check` drift-clean: idiolect's own `dev.idiolect.*` emit is byte-identical (no collisions in that family — every leaf TypeName is already unique, so the disambiguation pass leaves everything as-is). Only the family.rs preamble grows: per-record `use crate::generated::dev::idiolect::<x>::<Ty>;` lines that prettyplease collapses when the alias matches the raw ident.
- `cargo test --workspace --all-features` green. `tests/layers_family.rs` gains positive assertions on the disambiguated variants (`ChangelogEntry`, `ResourceEntry`), pairwise-uniqueness on every variant ident, and a guard that the unqualified `crate::Entry` shortcut is absent from the rendered Rust.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- `cargo fmt --all -- --check` clean.
- `bun run typecheck` / `bun run test` / `bun run lint` clean (no TypeScript touched).

## Architecture notes

The disambiguation pass that already lives in `mod.rs` (`walk_up_aliases` + `rust_module_path`) is now `pub(super)` so the family emitter can share it. The family emitter's `Entry` IR gains an `import: TokenStream` field carrying the per-record `use crate::generated::<…>::<raw_ty> as <ident>;` line, spliced into the rendered output between the existing crate-level imports and the `AnyRecord` declaration. `Entry::ty` and `Entry::nsid_path` route through the local alias rather than the crate root, so adding records under colliding leaves doesn't require any other emitter to change.

The fix decouples `family.rs` from any `pub use generated::*` flattening a downstream crate may or may not do at its root: the family module is self-sufficient regardless of how the consumer crate exposes its generated tree.

## Checklist

- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass locally.
- [x] `cargo test --workspace` passes locally.
- [x] `bun run typecheck && bun run test` pass.
- [x] Generated sources are up-to-date (`idiolect-codegen check` drift-clean).
- [x] Relevant sections of `CHANGELOG.md` under `[Unreleased]` updated. (Moved into a fresh `[0.6.1]` section in the same commit since the patch bump rides this PR.)