### PR TITLE
fix(lens): add Send bounds to Resolver/SchemaLoader trait futures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ if you depend on this project, and read this file before bumping.
 
 ### Security
 
+## [0.8.0] — 2026-05-04
+
+### Changed
+
+- `idiolect_lens::Resolver::resolve` and `idiolect_lens::SchemaLoader::load` now return `Pin<Box<dyn Future<...> + Send + '_>>` instead of bare `async fn`. The traits are object-safe (`Arc<dyn Resolver>`, `Arc<dyn SchemaLoader>`) and `apply_lens(...)`'s composed future is `Send`, so downstream callers can hold these behind a trait object and call `apply_lens` from inside an `#[async_trait]` impl without losing `Send` on the resulting future. `idiolect_lens::PdsClient` and `idiolect_lens::PanprotoVcsClient` tighten to `impl Future<...> + Send` on every method (RPITIT) so impls of `Resolver` that delegate to them stay `Send`. `dyn`-style impls of `Resolver` / `SchemaLoader` wrap their body in `Box::pin(async move { ... })`; `async fn` impls of `PdsClient` / `PanprotoVcsClient` whose bodies are already `Send` compile unchanged. Closes idiolect-dev/idiolect#53.
+
 ## [0.7.0] — 2026-04-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,7 +1296,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1314,7 +1314,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1336,7 +1336,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1368,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1394,7 +1394,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1412,7 +1412,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1450,7 +1450,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1472,7 +1472,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "cid",
  "language-tags",
@@ -1485,7 +1485,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,9 +18,9 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.7.0", path = "../idiolect-records" }
-idiolect-identity = { version = "0.7.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.7.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-records  = { version = "0.8.0", path = "../idiolect-records" }
+idiolect-identity = { version = "0.8.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.8.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.7.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.8.0", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.7.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.8.0", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.7.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.8.0", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.7.0", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.8.0", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-lens/src/caching_resolver.rs
+++ b/crates/idiolect-lens/src/caching_resolver.rs
@@ -91,40 +91,47 @@ impl<R> CachingResolver<R> {
 }
 
 impl<R: Resolver> Resolver for CachingResolver<R> {
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-        let key = uri.to_string();
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            let key = uri.to_string();
 
-        // Fast path: fresh hit.
-        if self.ttl > Duration::ZERO {
-            let entries = self
-                .entries
-                .lock()
-                .map_err(|e| LensError::Transport(format!("cache poisoned: {e}")))?;
-            if let Some(entry) = entries.get(&key)
-                && entry.inserted_at.elapsed() < self.ttl
-            {
-                return Ok(entry.lens.clone());
+            // Fast path: fresh hit.
+            if self.ttl > Duration::ZERO {
+                let entries = self
+                    .entries
+                    .lock()
+                    .map_err(|e| LensError::Transport(format!("cache poisoned: {e}")))?;
+                if let Some(entry) = entries.get(&key)
+                    && entry.inserted_at.elapsed() < self.ttl
+                {
+                    return Ok(entry.lens.clone());
+                }
             }
-        }
 
-        // Miss or expired: resolve, then insert.
-        let lens = self.inner.resolve(uri).await?;
+            // Miss or expired: resolve, then insert.
+            let lens = self.inner.resolve(uri).await?;
 
-        if self.ttl > Duration::ZERO {
-            let mut entries = self
-                .entries
-                .lock()
-                .map_err(|e| LensError::Transport(format!("cache poisoned: {e}")))?;
-            entries.insert(
-                key,
-                CacheEntry {
-                    lens: lens.clone(),
-                    inserted_at: Instant::now(),
-                },
-            );
-        }
+            if self.ttl > Duration::ZERO {
+                let mut entries = self
+                    .entries
+                    .lock()
+                    .map_err(|e| LensError::Transport(format!("cache poisoned: {e}")))?;
+                entries.insert(
+                    key,
+                    CacheEntry {
+                        lens: lens.clone(),
+                        inserted_at: Instant::now(),
+                    },
+                );
+            }
 
-        Ok(lens)
+            Ok(lens)
+        })
     }
 }
 
@@ -141,9 +148,16 @@ mod tests {
     }
 
     impl Resolver for CountingResolver {
-        async fn resolve(&self, _uri: &AtUri) -> Result<PanprotoLens, LensError> {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-            Ok(self.response.clone())
+        fn resolve<'a>(
+            &'a self,
+            _uri: &'a AtUri,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+        > {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Ok(self.response.clone())
+            })
         }
     }
 
@@ -153,9 +167,16 @@ mod tests {
     }
 
     impl Resolver for FailingResolver {
-        async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-            self.calls.fetch_add(1, Ordering::SeqCst);
-            Err(LensError::NotFound(uri.to_string()))
+        fn resolve<'a>(
+            &'a self,
+            uri: &'a AtUri,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+        > {
+            Box::pin(async move {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                Err(LensError::NotFound(uri.to_string()))
+            })
         }
     }
 

--- a/crates/idiolect-lens/src/resolver.rs
+++ b/crates/idiolect-lens/src/resolver.rs
@@ -48,11 +48,10 @@ use crate::error::LensError;
 /// test double for a live PDS client changes a constructor arg, not a
 /// call site.
 ///
-/// The trait uses native async fn; `async_fn_in_trait` is allowed at
-/// the crate level. `Send + Sync` bounds are required so the
-/// resolver can be shared across tokio tasks and its futures stay
-/// `Send`.
-#[allow(async_fn_in_trait)]
+/// The trait returns boxed `Send` futures so it stays object-safe
+/// (`Arc<dyn Resolver>`) and so [`apply_lens`](crate::apply_lens)'s
+/// composed future is `Send` when called from inside another async
+/// trait method.
 pub trait Resolver: Send + Sync {
     /// Fetch the lens record identified by `uri`.
     ///
@@ -62,7 +61,12 @@ pub trait Resolver: Send + Sync {
     /// produces. Backend-specific errors are wrapped into one of those
     /// variants at the resolver layer; callers never pattern-match on
     /// transport types.
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError>;
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    >;
 }
 
 // -----------------------------------------------------------------
@@ -106,11 +110,18 @@ impl InMemoryResolver {
 }
 
 impl Resolver for InMemoryResolver {
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-        self.entries
-            .get(&uri.to_string())
-            .cloned()
-            .ok_or_else(|| LensError::NotFound(uri.to_string()))
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            self.entries
+                .get(&uri.to_string())
+                .cloned()
+                .ok_or_else(|| LensError::NotFound(uri.to_string()))
+        })
     }
 }
 
@@ -118,8 +129,13 @@ impl Resolver for InMemoryResolver {
 /// resolver instance be shared across the lens runtime, the caching
 /// layer, and any other consumer without a manual delegate impl.
 impl<T: Resolver + ?Sized> Resolver for std::sync::Arc<T> {
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-        (**self).resolve(uri).await
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    > {
+        (**self).resolve(uri)
     }
 }
 
@@ -134,7 +150,6 @@ impl<T: Resolver + ?Sized> Resolver for std::sync::Arc<T> {
 /// the http request. The returned json is the raw record body
 /// (the `value` field of the xrpc response, not the response
 /// envelope).
-#[allow(async_fn_in_trait)]
 pub trait PdsClient: Send + Sync {
     /// Fetch a record's body json by repo / collection / rkey.
     ///
@@ -145,18 +160,18 @@ pub trait PdsClient: Send + Sync {
     /// [`LensError::Transport`] for any other failure. Decode errors
     /// are surfaced by the caller (`PdsResolver::resolve`), not by the
     /// client itself, since the client returns raw json.
-    async fn get_record(
+    fn get_record(
         &self,
         did: &str,
         collection: &str,
         rkey: &str,
-    ) -> Result<serde_json::Value, LensError>;
+    ) -> impl std::future::Future<Output = Result<serde_json::Value, LensError>> + Send;
 
     /// List records in a repo + collection, paginated.
     ///
     /// Mirrors `com.atproto.repo.listRecords`. Returns
     /// `(records, next_cursor)` where each record is the xrpc
-    /// response's `records[i]` shape — `{ uri, cid, value }` — and
+    /// response's `records[i]` shape (`{ uri, cid, value }`), and
     /// `next_cursor` is `Some(s)` when more records exist.
     ///
     /// The default implementation returns
@@ -169,16 +184,18 @@ pub trait PdsClient: Send + Sync {
     ///
     /// Returns [`LensError::Transport`] for backend failures. A
     /// `repo not found` returns [`LensError::NotFound`].
-    async fn list_records(
+    fn list_records(
         &self,
         _did: &str,
         _collection: &str,
         _limit: Option<u32>,
         _cursor: Option<&str>,
-    ) -> Result<ListRecordsResponse, LensError> {
-        Err(LensError::Transport(
-            "list_records not implemented on this PdsClient".into(),
-        ))
+    ) -> impl std::future::Future<Output = Result<ListRecordsResponse, LensError>> + Send {
+        async {
+            Err(LensError::Transport(
+                "list_records not implemented on this PdsClient".into(),
+            ))
+        }
     }
 }
 
@@ -258,13 +275,20 @@ impl<T: PdsClient + ?Sized> PdsClient for std::sync::Arc<T> {
 }
 
 impl<C: PdsClient> Resolver for PdsResolver<C> {
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-        let body = self
-            .client
-            .get_record(uri.did().as_str(), uri.collection().as_str(), uri.rkey())
-            .await?;
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            let body = self
+                .client
+                .get_record(uri.did().as_str(), uri.collection().as_str(), uri.rkey())
+                .await?;
 
-        serde_json::from_value::<PanprotoLens>(body).map_err(LensError::from)
+            serde_json::from_value::<PanprotoLens>(body).map_err(LensError::from)
+        })
     }
 }
 
@@ -435,7 +459,6 @@ impl<T: PdsWriter + ?Sized> PdsWriter for std::sync::Arc<T> {
 /// (`listTheories` / `listAlignments`). Concrete impls in scope for
 /// idiolect: a live client that speaks the xrpc surface, and the
 /// [`InMemoryVcsClient`] fixture shipped below.
-#[allow(async_fn_in_trait)]
 pub trait PanprotoVcsClient: Send + Sync {
     /// Fetch the content-addressed object identified by `object_hash`.
     ///
@@ -443,7 +466,10 @@ pub trait PanprotoVcsClient: Send + Sync {
     ///
     /// Return [`LensError::NotFound`] when no object matches the hash
     /// and [`LensError::Transport`] for any backend-level failure.
-    async fn get_object(&self, object_hash: &str) -> Result<serde_json::Value, LensError>;
+    fn get_object(
+        &self,
+        object_hash: &str,
+    ) -> impl std::future::Future<Output = Result<serde_json::Value, LensError>> + Send;
 
     /// Resolve a ref name to its current object hash, or `None` if
     /// the ref does not exist.
@@ -451,14 +477,21 @@ pub trait PanprotoVcsClient: Send + Sync {
     /// # Errors
     ///
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn get_ref(&self, name: &str) -> Result<Option<String>, LensError>;
+    fn get_ref(
+        &self,
+        name: &str,
+    ) -> impl std::future::Future<Output = Result<Option<String>, LensError>> + Send;
 
     /// Point `name` at `object_hash`. Creates the ref if absent.
     ///
     /// # Errors
     ///
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn set_ref(&self, name: &str, object_hash: &str) -> Result<(), LensError>;
+    fn set_ref(
+        &self,
+        name: &str,
+        object_hash: &str,
+    ) -> impl std::future::Future<Output = Result<(), LensError>> + Send;
 
     /// List every `(name, object_hash)` ref the store knows about.
     /// Order is implementation-defined.
@@ -466,7 +499,9 @@ pub trait PanprotoVcsClient: Send + Sync {
     /// # Errors
     ///
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn list_refs(&self) -> Result<Vec<(String, String)>, LensError>;
+    fn list_refs(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<(String, String)>, LensError>> + Send;
 
     /// Walk the commit chain starting at `ref_name`'s head, oldest-
     /// to-newest. `limit = None` means "every commit reachable".
@@ -476,11 +511,11 @@ pub trait PanprotoVcsClient: Send + Sync {
     ///
     /// [`LensError::NotFound`] when the ref is unknown,
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn list_commits(
+    fn list_commits(
         &self,
         ref_name: &str,
         limit: Option<u32>,
-    ) -> Result<Vec<String>, LensError>;
+    ) -> impl std::future::Future<Output = Result<Vec<String>, LensError>> + Send;
 
     /// Object hash of the most recent commit at `ref_name`, or `None`
     /// when the ref is empty.
@@ -488,7 +523,10 @@ pub trait PanprotoVcsClient: Send + Sync {
     /// # Errors
     ///
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn get_head(&self, ref_name: &str) -> Result<Option<String>, LensError>;
+    fn get_head(
+        &self,
+        ref_name: &str,
+    ) -> impl std::future::Future<Output = Result<Option<String>, LensError>> + Send;
 
     /// Fetch the cst-shaped schema tree rooted at `object_hash`.
     /// Used by the lens runtime when it needs the structural view of
@@ -498,14 +536,19 @@ pub trait PanprotoVcsClient: Send + Sync {
     ///
     /// [`LensError::NotFound`] when the tree is missing,
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn get_schema_tree(&self, object_hash: &str) -> Result<serde_json::Value, LensError>;
+    fn get_schema_tree(
+        &self,
+        object_hash: &str,
+    ) -> impl std::future::Future<Output = Result<serde_json::Value, LensError>> + Send;
 
     /// List every theory id the store recognises (registry view).
     ///
     /// # Errors
     ///
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn list_theories(&self) -> Result<Vec<String>, LensError>;
+    fn list_theories(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<String>, LensError>> + Send;
 
     /// List every theory-alignment id the store recognises (registry
     /// view used by the verify runners to find proof artifacts).
@@ -513,7 +556,9 @@ pub trait PanprotoVcsClient: Send + Sync {
     /// # Errors
     ///
     /// [`LensError::Transport`] for any backend-level failure.
-    async fn list_alignments(&self) -> Result<Vec<String>, LensError>;
+    fn list_alignments(
+        &self,
+    ) -> impl std::future::Future<Output = Result<Vec<String>, LensError>> + Send;
 }
 
 /// Resolves lens records by asking a [`PanprotoVcsClient`] for the
@@ -554,17 +599,24 @@ impl<C: PanprotoVcsClient> PanprotoVcsResolver<C> {
 }
 
 impl<C: PanprotoVcsClient> Resolver for PanprotoVcsResolver<C> {
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-        let key = uri.to_string();
-        let object_hash = self
-            .client
-            .get_ref(&key)
-            .await?
-            .ok_or(LensError::NotFound(key))?;
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            let key = uri.to_string();
+            let object_hash = self
+                .client
+                .get_ref(&key)
+                .await?
+                .ok_or(LensError::NotFound(key))?;
 
-        let body = self.client.get_object(&object_hash).await?;
+            let body = self.client.get_object(&object_hash).await?;
 
-        serde_json::from_value::<PanprotoLens>(body).map_err(LensError::from)
+            serde_json::from_value::<PanprotoLens>(body).map_err(LensError::from)
+        })
     }
 }
 
@@ -796,6 +848,19 @@ mod tests {
 
         let err = r.resolve(&uri).await.unwrap_err();
         assert!(matches!(err, LensError::NotFound(_)));
+    }
+
+    /// Pins the cross-task contract: `Arc<dyn Resolver>` is object-safe
+    /// and its `resolve` future is `Send`, so downstream callers can
+    /// hold a resolver behind a trait object and `.await` it inside an
+    /// async-trait method without losing `Send` on the composed future.
+    #[test]
+    fn resolver_trait_object_future_is_send() {
+        fn assert_send<T: Send>(_: &T) {}
+        let r: std::sync::Arc<dyn Resolver> = std::sync::Arc::new(InMemoryResolver::new());
+        let uri = crate::AtUri::parse("at://did:plc:x/dev.panproto.schema.lens/l1").unwrap();
+        let fut = r.resolve(&uri);
+        assert_send(&fut);
     }
 
     struct StaticPdsClient(serde_json::Value);

--- a/crates/idiolect-lens/src/schema_loader.rs
+++ b/crates/idiolect-lens/src/schema_loader.rs
@@ -21,7 +21,6 @@ use crate::error::LensError;
 /// Implementations should return [`LensError::NotFound`] when no
 /// schema matches the given hash and [`LensError::Transport`] for
 /// backend-level failures.
-#[allow(async_fn_in_trait)]
 pub trait SchemaLoader: Send + Sync {
     /// Load the schema whose content-addressed hash is `object_hash`.
     ///
@@ -31,9 +30,9 @@ pub trait SchemaLoader: Send + Sync {
     /// schema unioned across many files (`getProjectSchema`), or
     /// anything content-addressed and deserialisable as a panproto
     /// `Schema`. Dialects routinely span several source schemas, so
-    /// the runtime intentionally avoids assuming a particular scope —
-    /// it asks the loader for "the schema at this hash" and instantiates
-    /// against whatever it gets back.
+    /// the runtime intentionally avoids assuming a particular scope.
+    /// It asks the loader for "the schema at this hash" and
+    /// instantiates against whatever it gets back.
     ///
     /// # Errors
     ///
@@ -41,7 +40,10 @@ pub trait SchemaLoader: Send + Sync {
     /// unknown; `Transport` when the backend fails; `LexiconParse`
     /// when the backend returned bytes that were not a valid
     /// panproto schema graph.
-    async fn load(&self, object_hash: &str) -> Result<Schema, LensError>;
+    fn load<'a>(
+        &'a self,
+        object_hash: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Schema, LensError>> + Send + 'a>>;
 }
 
 /// A `HashMap`-backed schema loader, keyed by `object_hash`.
@@ -81,18 +83,28 @@ impl InMemorySchemaLoader {
 }
 
 impl SchemaLoader for InMemorySchemaLoader {
-    async fn load(&self, object_hash: &str) -> Result<Schema, LensError> {
-        self.entries
-            .get(object_hash)
-            .cloned()
-            .ok_or_else(|| LensError::NotFound(format!("schema:{object_hash}")))
+    fn load<'a>(
+        &'a self,
+        object_hash: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Schema, LensError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            self.entries
+                .get(object_hash)
+                .cloned()
+                .ok_or_else(|| LensError::NotFound(format!("schema:{object_hash}")))
+        })
     }
 }
 
 /// Forward [`SchemaLoader`] through a shared `Arc<T>`.
 impl<T: SchemaLoader + ?Sized> SchemaLoader for std::sync::Arc<T> {
-    async fn load(&self, object_hash: &str) -> Result<Schema, LensError> {
-        (**self).load(object_hash).await
+    fn load<'a>(
+        &'a self,
+        object_hash: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Schema, LensError>> + Send + 'a>>
+    {
+        (**self).load(object_hash)
     }
 }
 
@@ -155,24 +167,30 @@ impl FilesystemSchemaLoader {
 }
 
 impl SchemaLoader for FilesystemSchemaLoader {
-    async fn load(&self, object_hash: &str) -> Result<Schema, LensError> {
-        let path = self.path_for(object_hash);
-        let bytes = match std::fs::read(&path) {
-            Ok(b) => b,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                return Err(LensError::NotFound(format!("schema:{object_hash}")));
-            }
-            Err(e) => {
-                return Err(LensError::Transport(format!(
-                    "read {}: {e}",
-                    path.display()
-                )));
-            }
-        };
-        let value: serde_json::Value = serde_json::from_slice(&bytes)
-            .map_err(|e| LensError::Transport(format!("parse {}: {e}", path.display())))?;
-        panproto_protocols::web_document::atproto::parse_lexicon(&value)
-            .map_err(|e| LensError::Transport(format!("lexicon parse {object_hash}: {e}")))
+    fn load<'a>(
+        &'a self,
+        object_hash: &'a str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<Schema, LensError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let path = self.path_for(object_hash);
+            let bytes = match std::fs::read(&path) {
+                Ok(b) => b,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(LensError::NotFound(format!("schema:{object_hash}")));
+                }
+                Err(e) => {
+                    return Err(LensError::Transport(format!(
+                        "read {}: {e}",
+                        path.display()
+                    )));
+                }
+            };
+            let value: serde_json::Value = serde_json::from_slice(&bytes)
+                .map_err(|e| LensError::Transport(format!("parse {}: {e}", path.display())))?;
+            panproto_protocols::web_document::atproto::parse_lexicon(&value)
+                .map_err(|e| LensError::Transport(format!("lexicon parse {object_hash}: {e}")))
+        })
     }
 }
 
@@ -226,6 +244,14 @@ mod tests {
         let loader = FilesystemSchemaLoader::new(dir.path()).unwrap();
         let err = loader.load("sha256:absent").await.unwrap_err();
         assert!(matches!(err, LensError::NotFound(_)));
+    }
+
+    #[test]
+    fn schema_loader_trait_object_future_is_send() {
+        fn assert_send<T: Send>(_: &T) {}
+        let l: std::sync::Arc<dyn SchemaLoader> = std::sync::Arc::new(InMemorySchemaLoader::new());
+        let fut = l.load("sha256:abc");
+        assert_send(&fut);
     }
 
     #[tokio::test]

--- a/crates/idiolect-lens/src/verifying_resolver.rs
+++ b/crates/idiolect-lens/src/verifying_resolver.rs
@@ -227,31 +227,38 @@ impl<R> VerifyingResolver<R, Sha256Hasher> {
 }
 
 impl<R: Resolver, H: Hasher> Resolver for VerifyingResolver<R, H> {
-    async fn resolve(&self, uri: &AtUri) -> Result<PanprotoLens, LensError> {
-        let lens = self.inner.resolve(uri).await?;
+    fn resolve<'a>(
+        &'a self,
+        uri: &'a AtUri,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
+    > {
+        Box::pin(async move {
+            let lens = self.inner.resolve(uri).await?;
 
-        let (algo, expected) = split_hash(&lens.object_hash).ok_or_else(|| {
-            LensError::Transport(format!(
-                "malformed object_hash (expected `<algo>:<hex>`): {}",
-                lens.object_hash
-            ))
-        })?;
-        if algo != self.hasher.algorithm() {
-            return Err(LensError::Transport(format!(
-                "object_hash algorithm {algo} does not match verifier algorithm {}",
-                self.hasher.algorithm()
-            )));
-        }
+            let (algo, expected) = split_hash(&lens.object_hash).ok_or_else(|| {
+                LensError::Transport(format!(
+                    "malformed object_hash (expected `<algo>:<hex>`): {}",
+                    lens.object_hash
+                ))
+            })?;
+            if algo != self.hasher.algorithm() {
+                return Err(LensError::Transport(format!(
+                    "object_hash algorithm {algo} does not match verifier algorithm {}",
+                    self.hasher.algorithm()
+                )));
+            }
 
-        let bytes = canonical_blob_bytes(&lens)?;
-        let actual = self.hasher.hash_hex(&bytes);
-        if actual != expected {
-            return Err(LensError::Transport(format!(
-                "content hash mismatch for {uri}: declared {algo}:{expected}, computed {algo}:{actual}"
-            )));
-        }
+            let bytes = canonical_blob_bytes(&lens)?;
+            let actual = self.hasher.hash_hex(&bytes);
+            if actual != expected {
+                return Err(LensError::Transport(format!(
+                    "content hash mismatch for {uri}: declared {algo}:{expected}, computed {algo}:{actual}"
+                )));
+            }
 
-        Ok(lens)
+            Ok(lens)
+        })
     }
 }
 

--- a/crates/idiolect-lens/tests/send_bounds.rs
+++ b/crates/idiolect-lens/tests/send_bounds.rs
@@ -1,0 +1,408 @@
+//! Pins the cross-task `Send` contract on `Resolver`, `SchemaLoader`,
+//! `PdsClient`, and `PanprotoVcsClient`.
+//!
+//! Before this fix the trait methods were declared as bare
+//! `async fn`, which produced `?Send` futures at the trait boundary.
+//! Composed futures (notably `apply_lens(...)`) leaked the `?Send`
+//! out, blocking downstream callers from holding these resolvers
+//! behind `Arc<dyn Resolver>` and calling `apply_lens` from inside
+//! an `#[async_trait]` impl. Each test below would fail to compile
+//! if the trait declarations regressed.
+
+#![allow(dead_code, clippy::missing_panics_doc)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use idiolect_lens::{
+    ApplyLensInput, AtUri, CachingResolver, CreateRecordRequest, DeleteRecordRequest,
+    InMemoryResolver, InMemorySchemaLoader, InMemoryVcsClient, LensError, ListRecordsResponse,
+    PanprotoVcsClient, PanprotoVcsResolver, PdsClient, PdsResolver, PdsWriter, PutRecordRequest,
+    Resolver, SchemaLoader, VerifyingResolver, WriteRecordResponse, apply_lens,
+};
+use idiolect_records::{AtUri as RecordAtUri, Datetime, PanprotoLens};
+use panproto_lens::protolens::elementary;
+use panproto_schema::{Protocol, Schema, SchemaBuilder};
+
+// -----------------------------------------------------------------
+// helpers
+// -----------------------------------------------------------------
+
+fn assert_send<T: Send>(_: &T) {}
+fn assert_send_sync<T: Send + Sync>(_: &T) {}
+
+fn fixture_lens(src_hash: &str, tgt_hash: &str) -> PanprotoLens {
+    PanprotoLens {
+        blob: None,
+        created_at: Datetime::parse("2026-04-19T00:00:00.000Z").unwrap(),
+        laws_verified: Some(true),
+        object_hash: "sha256:deadbeef".into(),
+        round_trip_class: Some("isomorphism".into()),
+        source_schema: RecordAtUri::parse(src_hash).unwrap(),
+        target_schema: RecordAtUri::parse(tgt_hash).unwrap(),
+    }
+}
+
+fn lens_uri() -> AtUri {
+    AtUri::parse("at://did:plc:xyz/dev.panproto.schema.lens/l1").unwrap()
+}
+
+// -----------------------------------------------------------------
+// Resolver: futures are Send and the trait is object-safe
+// -----------------------------------------------------------------
+
+#[test]
+fn in_memory_resolver_future_is_send() {
+    let r = InMemoryResolver::new();
+    let uri = lens_uri();
+    assert_send(&r.resolve(&uri));
+}
+
+#[test]
+fn arc_dyn_resolver_compiles_and_future_is_send() {
+    let r: Arc<dyn Resolver> = Arc::new(InMemoryResolver::new());
+    assert_send_sync(&r);
+    let uri = lens_uri();
+    assert_send(&r.resolve(&uri));
+}
+
+#[test]
+fn caching_resolver_over_dyn_resolver_future_is_send() {
+    let inner: Arc<dyn Resolver> = Arc::new(InMemoryResolver::new());
+    let cached = CachingResolver::new(inner, std::time::Duration::from_secs(60));
+    let uri = lens_uri();
+    assert_send(&cached.resolve(&uri));
+}
+
+#[test]
+fn verifying_resolver_over_dyn_resolver_future_is_send() {
+    let inner: Arc<dyn Resolver> = Arc::new(InMemoryResolver::new());
+    let v = VerifyingResolver::sha256(inner);
+    let uri = lens_uri();
+    assert_send(&v.resolve(&uri));
+}
+
+// -----------------------------------------------------------------
+// SchemaLoader: futures are Send and the trait is object-safe
+// -----------------------------------------------------------------
+
+#[test]
+fn in_memory_schema_loader_future_is_send() {
+    let l = InMemorySchemaLoader::new();
+    assert_send(&l.load("sha256:abc"));
+}
+
+#[test]
+fn arc_dyn_schema_loader_compiles_and_future_is_send() {
+    let l: Arc<dyn SchemaLoader> = Arc::new(InMemorySchemaLoader::new());
+    assert_send_sync(&l);
+    assert_send(&l.load("sha256:abc"));
+}
+
+// -----------------------------------------------------------------
+// apply_lens(): the composed future is Send when both R and S are
+// trait objects. The crux of the issue this test guards against.
+// -----------------------------------------------------------------
+
+#[test]
+fn apply_lens_future_is_send_with_dyn_resolver_and_loader() {
+    let resolver: Arc<dyn Resolver> = Arc::new(InMemoryResolver::new());
+    let loader: Arc<dyn SchemaLoader> = Arc::new(InMemorySchemaLoader::new());
+    let protocol = Protocol::default();
+
+    // Build the future without driving it; just typecheck `Send`.
+    let fut = apply_lens(
+        &resolver,
+        &loader,
+        &protocol,
+        ApplyLensInput {
+            lens_uri: lens_uri(),
+            source_record: serde_json::json!({}),
+            source_root_vertex: None,
+        },
+    );
+    assert_send(&fut);
+}
+
+// -----------------------------------------------------------------
+// apply_lens(): end-to-end, driving the future through a tokio
+// `spawn` (which requires `Send`) over `Arc<dyn ...>` resolvers.
+// Confirms the Send contract is not just type-checked but works
+// across task boundaries.
+// -----------------------------------------------------------------
+
+fn test_protocol() -> Protocol {
+    Protocol::default()
+}
+
+fn single_field_source_schema() -> Schema {
+    SchemaBuilder::new(&test_protocol())
+        .entry("post:body")
+        .vertex("post:body", "object", None)
+        .unwrap()
+        .vertex("post:body.text", "string", None)
+        .unwrap()
+        .edge("post:body", "post:body.text", "prop", Some("text"))
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+#[tokio::test]
+async fn apply_lens_runs_through_tokio_spawn_with_dyn_resolvers() {
+    let protocol = test_protocol();
+    let src_schema = single_field_source_schema();
+    let protolens = elementary::rename_sort("string", "text");
+    let tgt_schema = protolens.target_schema(&src_schema, &protocol).unwrap();
+
+    let src_hash = "at://did:plc:x/dev.panproto.schema.schema/src";
+    let tgt_hash = "at://did:plc:x/dev.panproto.schema.schema/tgt";
+
+    let mut concrete_loader = InMemorySchemaLoader::new();
+    concrete_loader.insert(src_hash.to_owned(), src_schema);
+    concrete_loader.insert(tgt_hash.to_owned(), tgt_schema);
+
+    let mut concrete_resolver = InMemoryResolver::new();
+    let lens_uri = lens_uri();
+    let mut record = fixture_lens(src_hash, tgt_hash);
+    record.blob = Some(serde_json::to_value(&protolens).unwrap());
+    concrete_resolver.insert(&lens_uri, record);
+
+    let resolver: Arc<dyn Resolver> = Arc::new(concrete_resolver);
+    let loader: Arc<dyn SchemaLoader> = Arc::new(concrete_loader);
+
+    // tokio::spawn requires the future to be `Send + 'static`. This
+    // is the canonical way downstream callers (e.g. an axum handler)
+    // would invoke `apply_lens` over trait-object dependencies.
+    let handle = tokio::spawn({
+        let resolver = Arc::clone(&resolver);
+        let loader = Arc::clone(&loader);
+        let lens_uri = lens_uri.clone();
+        async move {
+            apply_lens(
+                &resolver,
+                &loader,
+                &test_protocol(),
+                ApplyLensInput {
+                    lens_uri,
+                    source_record: serde_json::json!({ "text": "hello" }),
+                    source_root_vertex: None,
+                },
+            )
+            .await
+        }
+    });
+
+    let out = handle.await.unwrap().expect("forward apply_lens");
+    assert_eq!(out.target_record, serde_json::json!({ "text": "hello" }));
+}
+
+// -----------------------------------------------------------------
+// Wraps apply_lens inside an async-trait-shaped Send future, the
+// exact pattern the issue describes (LensApplier in a downstream
+// orchestrator). The compiler error this would have produced
+// before the fix is the one cited in the issue body.
+// -----------------------------------------------------------------
+
+trait LensApplier: Send + Sync {
+    fn apply<'a>(
+        &'a self,
+        lens_uri: &'a AtUri,
+        record: serde_json::Value,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, LensError>> + Send + 'a>>;
+}
+
+struct PanprotoLensApplier {
+    resolver: Arc<dyn Resolver>,
+    loader: Arc<dyn SchemaLoader>,
+    protocol: Protocol,
+}
+
+impl LensApplier for PanprotoLensApplier {
+    fn apply<'a>(
+        &'a self,
+        lens_uri: &'a AtUri,
+        record: serde_json::Value,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, LensError>> + Send + 'a>>
+    {
+        Box::pin(async move {
+            let out = apply_lens(
+                &self.resolver,
+                &self.loader,
+                &self.protocol,
+                ApplyLensInput {
+                    lens_uri: lens_uri.clone(),
+                    source_record: record,
+                    source_root_vertex: None,
+                },
+            )
+            .await?;
+            Ok(out.target_record)
+        })
+    }
+}
+
+#[tokio::test]
+async fn lens_applier_trait_object_drives_apply_lens() {
+    let protocol = test_protocol();
+    let src_schema = single_field_source_schema();
+    let protolens = elementary::rename_sort("string", "text");
+    let tgt_schema = protolens.target_schema(&src_schema, &protocol).unwrap();
+
+    let src_hash = "at://did:plc:x/dev.panproto.schema.schema/src";
+    let tgt_hash = "at://did:plc:x/dev.panproto.schema.schema/tgt";
+
+    let mut concrete_loader = InMemorySchemaLoader::new();
+    concrete_loader.insert(src_hash.to_owned(), src_schema);
+    concrete_loader.insert(tgt_hash.to_owned(), tgt_schema);
+
+    let mut concrete_resolver = InMemoryResolver::new();
+    let lens_uri = lens_uri();
+    let mut record = fixture_lens(src_hash, tgt_hash);
+    record.blob = Some(serde_json::to_value(&protolens).unwrap());
+    concrete_resolver.insert(&lens_uri, record);
+
+    let applier: Arc<dyn LensApplier> = Arc::new(PanprotoLensApplier {
+        resolver: Arc::new(concrete_resolver),
+        loader: Arc::new(concrete_loader),
+        protocol,
+    });
+
+    let out = applier
+        .apply(&lens_uri, serde_json::json!({ "text": "hi" }))
+        .await
+        .unwrap();
+    assert_eq!(out, serde_json::json!({ "text": "hi" }));
+}
+
+// -----------------------------------------------------------------
+// PdsClient and PanprotoVcsClient: every method's future is Send.
+// (RPITIT `+ Send` form, since these are not used as `dyn`.)
+// -----------------------------------------------------------------
+
+struct StubPdsClient;
+
+impl PdsClient for StubPdsClient {
+    async fn get_record(
+        &self,
+        _did: &str,
+        _collection: &str,
+        _rkey: &str,
+    ) -> Result<serde_json::Value, LensError> {
+        Ok(serde_json::Value::Null)
+    }
+}
+
+#[test]
+fn pds_client_get_record_future_is_send() {
+    let c = StubPdsClient;
+    assert_send(&c.get_record("did:plc:x", "col", "rkey"));
+    assert_send(&c.list_records("did:plc:x", "col", None, None));
+}
+
+#[test]
+fn pds_resolver_over_arc_pds_client_future_is_send() {
+    let client: Arc<dyn PdsClientObj> = Arc::new(StubPdsObjClient);
+    // PdsResolver is generic, so wrap a concrete client.
+    let r = PdsResolver::new(StubPdsClient);
+    let uri = lens_uri();
+    assert_send(&r.resolve(&uri));
+    drop(client);
+}
+
+// dyn-erased PdsClient surface for the test's Arc-of-dyn check above.
+// PdsClient itself is not dyn-safe under RPITIT, so we mirror the
+// surface the test needs through a small object-safe wrapper.
+trait PdsClientObj: Send + Sync {
+    fn get_record<'a>(
+        &'a self,
+        did: &'a str,
+        collection: &'a str,
+        rkey: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, LensError>> + Send + 'a>>;
+}
+
+struct StubPdsObjClient;
+
+impl PdsClientObj for StubPdsObjClient {
+    fn get_record<'a>(
+        &'a self,
+        _did: &'a str,
+        _collection: &'a str,
+        _rkey: &'a str,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, LensError>> + Send + 'a>>
+    {
+        Box::pin(async { Ok(serde_json::Value::Null) })
+    }
+}
+
+#[test]
+fn panproto_vcs_client_futures_are_send() {
+    let c = InMemoryVcsClient::new();
+    assert_send(&c.get_object("hash"));
+    assert_send(&c.get_ref("name"));
+    assert_send(&c.set_ref("name", "hash"));
+    assert_send(&c.list_refs());
+    assert_send(&c.list_commits("name", None));
+    assert_send(&c.get_head("name"));
+    assert_send(&c.get_schema_tree("hash"));
+    assert_send(&c.list_theories());
+    assert_send(&c.list_alignments());
+}
+
+#[test]
+fn panproto_vcs_resolver_future_is_send() {
+    let r = PanprotoVcsResolver::new(InMemoryVcsClient::new());
+    let uri = lens_uri();
+    assert_send(&r.resolve(&uri));
+}
+
+// -----------------------------------------------------------------
+// PdsWriter: its surface is unchanged by this fix, but make sure
+// its `async fn` methods still produce Send futures over a concrete
+// impl so downstream `Arc<T: PdsWriter>` callers stay `Send`.
+// -----------------------------------------------------------------
+
+struct StubPdsWriter;
+
+impl PdsWriter for StubPdsWriter {
+    async fn create_record(
+        &self,
+        _request: CreateRecordRequest,
+    ) -> Result<WriteRecordResponse, LensError> {
+        Ok(WriteRecordResponse {
+            uri: "at://did:plc:x/c/r".into(),
+            cid: "cid".into(),
+        })
+    }
+
+    async fn put_record(
+        &self,
+        _request: PutRecordRequest,
+    ) -> Result<WriteRecordResponse, LensError> {
+        Ok(WriteRecordResponse {
+            uri: "at://did:plc:x/c/r".into(),
+            cid: "cid".into(),
+        })
+    }
+
+    async fn delete_record(&self, _request: DeleteRecordRequest) -> Result<(), LensError> {
+        Ok(())
+    }
+}
+
+#[test]
+fn pds_writer_concrete_futures_are_send() {
+    let w = StubPdsWriter;
+    let req = CreateRecordRequest {
+        repo: "did:plc:x".into(),
+        collection: "c".into(),
+        rkey: None,
+        record: serde_json::json!({}),
+        validate: None,
+    };
+    assert_send(&w.create_record(req));
+}
+
+#[allow(dead_code)]
+fn assert_list_records_response_is_send(_: ListRecordsResponse) {}

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.7.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.7.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.8.0", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.8.0", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.7.0", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.7.0", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.8.0", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.8.0", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.7.0", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.8.0", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.7.0", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.7.0", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.8.0", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.8.0", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.7.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.7.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.8.0", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.8.0", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",


### PR DESCRIPTION
## Summary

- Tighten `idiolect_lens::Resolver::resolve` and `SchemaLoader::load` to return `Pin<Box<dyn Future + Send + '_>>`. The traits are object-safe (`Arc<dyn Resolver>`, `Arc<dyn SchemaLoader>`) and `apply_lens(...)`'s composed future is `Send`, so downstream callers can hold these behind a trait object and call `apply_lens` from inside an `#[async_trait]` impl without losing `Send` on the resulting future.
- Tighten `idiolect_lens::PdsClient` and `idiolect_lens::PanprotoVcsClient` methods to `impl Future + Send` (RPITIT) so impls of `Resolver` that delegate to them stay `Send`.
- New `crates/idiolect-lens/tests/send_bounds.rs` pins the contract: 14 tests covering concrete impls, `Arc<dyn ...>`, `CachingResolver` and `VerifyingResolver` over trait objects, the `apply_lens` composed future under `Arc<dyn ...>`, end-to-end driving through `tokio::spawn`, and an `Arc<dyn LensApplier>` pattern that mirrors the layers-pub orchestrator scenario from the issue.
- Bump workspace version 0.7.0 to 0.8.0 (trait surface change is breaking; pre-1.0 minor bump).

Closes #53.

## Migration

`async fn` impls of `Resolver` / `SchemaLoader` in downstream crates need to switch to the boxed-future shape:

```rust
impl Resolver for MyResolver {
    fn resolve<'a>(
        &'a self,
        uri: &'a AtUri,
    ) -> std::pin::Pin<
        Box<dyn std::future::Future<Output = Result<PanprotoLens, LensError>> + Send + 'a>,
    > {
        Box::pin(async move { /* existing body */ })
    }
}
```

`async fn` impls of `PdsClient` / `PanprotoVcsClient` whose bodies are already `Send` compile unchanged under the new `impl Future + Send` trait declarations.

## Test plan

- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p idiolect-lens --test send_bounds` (14/14 pass)