### PR TITLE
feat: runnable CLI subcommands (oauth/publish/verify/migrate) + refresh_if_needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ if you depend on this project, and read this file before bumping.
 
 ### Security
 
+## [0.10.0] — 2026-05-04
+
+### Added
+
+- `idiolect oauth login`, `idiolect oauth list`, `idiolect oauth logout` CLI subcommands. `login` exchanges a handle plus app password for an access JWT via `com.atproto.server.createSession` and persists the resulting session as a JSON file under `$IDIOLECT_SESSION_DIR` (default `~/.config/idiolect/sessions/`); `list` enumerates stored sessions; `logout` deletes one by DID. This path uses app passwords in legacy Bearer mode as a transitional step (ATProto is moving off app passwords in favour of OAuth + DPoP). The `OAuthSession` shape carries the DPoP private key field already; switching flows in a follow-up branch is a CLI substitution, not a session-shape change.
+- `idiolect publish <kind> --record <path> [--rkey RKEY] [--did DID]` CLI subcommand. Validates the JSON file against the typed `Record` impl (`decode_record(&nsid, value)`), splices in `$type`, and POSTs `com.atproto.repo.createRecord` under a stored session. Short kind names (e.g. `recommendation`) map to NSIDs (`dev.idiolect.recommendation`); rkey defaults to a TID-shaped value generated at publish time.
+- `idiolect verify roundtrip-test | property-test | static-check | coercion-law` CLI subcommands wrapping each of the four shipped `VerificationRunner` impls against a live PDS via `PdsResolver` plus `PdsSchemaLoader`. Corpus files may be JSON arrays or JSON Lines; `property-test` cycles the corpus by index and accepts `--budget N`; `coercion-law` talks to a panproto VCS service via `dev.panproto.translate.verifyCoercionLaws`. The CLI prints the typed `Verification` record as JSON and exits non-zero on `Falsified` or `Inconclusive`, suitable for CI gates.
+- `idiolect-migrate` batch CLI binary (behind the `cli` feature on `idiolect-migrate`). Streams a directory of JSON records through `migrate_record` against a published lens record, writes a target directory, and reflects per-record success in the exit code (0 if every file succeeded, 1 if any failed).
+- `idiolect_oauth::refresh_if_needed(&store, &refresher, did)`: generic helper that loads a session, decides whether to refresh based on the current wall clock plus a 60-second buffer, drives the caller-supplied `Refresher::refresh` if so, persists the result, and returns the live session. Generic over `S: OAuthTokenStore` plus `R: Refresher` because `OAuthTokenStore`'s async-fn-in-trait methods rule out trait-object form. The refresh HTTP call lives in whatever OAuth client the application uses; `idiolect-oauth` owns the storage and timing decision around it.
+- `deliberation-tally` registered in `observer-spec/methods.json`. The `DeliberationTallyMethod` implementation has shipped in `idiolect-observer` since v0.7.0 but was missing from the spec registry; codegen now generates the dispatch entry alongside the other observer methods.
+
 ## [0.9.0] — 2026-05-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,12 +1296,14 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "idiolect-identity",
  "idiolect-lens",
  "idiolect-records",
+ "idiolect-verify",
+ "panproto-schema",
  "reqwest",
  "serde",
  "serde_json",
@@ -1314,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1336,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1350,7 +1352,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1368,7 +1370,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1394,8 +1396,9 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
+ "anyhow",
  "idiolect-lens",
  "idiolect-records",
  "panproto-check",
@@ -1408,11 +1411,12 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1430,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1450,7 +1454,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1472,7 +1476,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "cid",
  "language-tags",
@@ -1485,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,9 +18,11 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.9.0", path = "../idiolect-records" }
-idiolect-identity = { version = "0.9.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.9.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-records  = { version = "0.10.0", path = "../idiolect-records" }
+idiolect-identity = { version = "0.10.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.10.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-verify   = { version = "0.10.0", path = "../idiolect-verify" }
+panproto-schema   = { workspace = true }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-cli/src/main.rs
+++ b/crates/idiolect-cli/src/main.rs
@@ -34,6 +34,10 @@ use tracing_subscriber::EnvFilter;
 
 mod encounter;
 mod generated;
+mod oauth;
+mod publish;
+mod util;
+mod verify;
 
 const DEFAULT_ORCHESTRATOR_URL: &str = "http://localhost:8787";
 
@@ -73,6 +77,18 @@ async fn parse_and_run() -> Result<ExitCode> {
                 "record" => encounter::cmd_encounter_record(&nested[1..]).await,
                 other => bail!("unknown encounter subcommand: {other}"),
             }
+        }
+        "oauth" => {
+            let nested: Vec<String> = args.collect();
+            oauth::dispatch(&nested).await
+        }
+        "publish" => {
+            let nested: Vec<String> = args.collect();
+            publish::dispatch(&nested).await
+        }
+        "verify" => {
+            let nested: Vec<String> = args.collect();
+            verify::dispatch(&nested).await
         }
         "version" | "--version" | "-V" => {
             println!("idiolect {}", env!("CARGO_PKG_VERSION"));

--- a/crates/idiolect-cli/src/oauth.rs
+++ b/crates/idiolect-cli/src/oauth.rs
@@ -1,0 +1,275 @@
+//! `idiolect oauth` — manage authenticated PDS sessions.
+//!
+//! Three subcommands:
+//!
+//! ```text
+//! idiolect oauth login  --handle H --app-password P --pds-url URL
+//! idiolect oauth list
+//! idiolect oauth logout --did D
+//! ```
+//!
+//! Sessions persist as one JSON file per DID under
+//! `~/.config/idiolect/sessions/` (override via `IDIOLECT_SESSION_DIR`).
+//! Each file carries the minimum fields the publisher path needs:
+//! `did`, `pds_url`, `access_jwt`, `refresh_jwt`.
+//!
+//! This is the app-password Bearer path. The full OAuth + `DPoP` flow
+//! (via `atrium-oauth-client`) is the planned upgrade; the file
+//! format here is forward-compatible with adding `dpop_private_key`
+//! later.
+
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, anyhow, bail};
+use serde::{Deserialize, Serialize};
+
+const DEFAULT_PDS_URL: &str = "https://bsky.social";
+
+/// On-disk session shape. One JSON file per DID.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CliSession {
+    pub did: String,
+    pub handle: Option<String>,
+    pub pds_url: String,
+    #[serde(rename = "accessJwt")]
+    pub access_jwt: String,
+    #[serde(rename = "refreshJwt")]
+    pub refresh_jwt: String,
+}
+
+impl CliSession {
+    /// Standard sessions directory.
+    pub fn dir() -> Result<PathBuf> {
+        if let Ok(p) = std::env::var("IDIOLECT_SESSION_DIR") {
+            return Ok(PathBuf::from(p));
+        }
+        let home = std::env::var("HOME").context("HOME env var")?;
+        Ok(PathBuf::from(home).join(".config/idiolect/sessions"))
+    }
+
+    /// Where on disk a session for `did` lives.
+    pub fn path_for(did: &str) -> Result<PathBuf> {
+        let mut filename = String::with_capacity(did.len() + 5);
+        for ch in did.chars() {
+            match ch {
+                ':' | '/' | '\\' | '\0' => filename.push('_'),
+                c => filename.push(c),
+            }
+        }
+        filename.push_str(".json");
+        Ok(Self::dir()?.join(filename))
+    }
+
+    /// Load the session for `did` from disk.
+    pub fn load(did: &str) -> Result<Self> {
+        let path = Self::path_for(did)?;
+        let bytes = std::fs::read(&path)
+            .with_context(|| format!("read session at {}", path.display()))?;
+        let session: Self = serde_json::from_slice(&bytes)
+            .with_context(|| format!("parse session at {}", path.display()))?;
+        Ok(session)
+    }
+
+    /// Save the session to disk. Creates the sessions dir if missing.
+    pub fn save(&self) -> Result<PathBuf> {
+        let path = Self::path_for(&self.did)?;
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("create {}", parent.display()))?;
+        }
+        let bytes = serde_json::to_vec_pretty(self)?;
+        std::fs::write(&path, bytes)
+            .with_context(|| format!("write session at {}", path.display()))?;
+        Ok(path)
+    }
+}
+
+pub async fn dispatch(args: &[String]) -> Result<ExitCode> {
+    let Some(sub) = args.first() else {
+        bail!("usage: idiolect oauth <login|list|logout> ...");
+    };
+    let rest = &args[1..];
+    match sub.as_str() {
+        "login" => cmd_login(rest).await,
+        "list" => cmd_list(rest),
+        "logout" => cmd_logout(rest),
+        other => bail!("unknown oauth subcommand: {other}"),
+    }
+}
+
+// -----------------------------------------------------------------
+// login
+// -----------------------------------------------------------------
+
+#[derive(Serialize)]
+struct CreateSessionRequest<'a> {
+    identifier: &'a str,
+    password: &'a str,
+}
+
+#[derive(Deserialize)]
+struct CreateSessionResponse {
+    did: String,
+    #[serde(rename = "accessJwt")]
+    access_jwt: String,
+    #[serde(rename = "refreshJwt")]
+    refresh_jwt: String,
+    #[serde(default)]
+    handle: Option<String>,
+}
+
+async fn cmd_login(args: &[String]) -> Result<ExitCode> {
+    let mut handle: Option<String> = None;
+    let mut password: Option<String> = None;
+    let mut pds_url = DEFAULT_PDS_URL.to_owned();
+
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--handle" => {
+                handle = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--handle requires a value"))?
+                        .clone(),
+                );
+            }
+            "--app-password" => {
+                password = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--app-password requires a value"))?
+                        .clone(),
+                );
+            }
+            "--pds-url" => {
+                pds_url = iter
+                    .next()
+                    .ok_or_else(|| anyhow!("--pds-url requires a value"))?
+                    .clone();
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+
+    let handle = handle.ok_or_else(|| anyhow!("--handle required"))?;
+    // Allow the password to come from env (so it doesn't end up in
+    // shell history) when --app-password is omitted.
+    let password = match password {
+        Some(p) => p,
+        None => std::env::var("ATPROTO_APP_PASSWORD")
+            .or_else(|_| std::env::var("ATPROTO_PASSWORD"))
+            .context(
+                "--app-password not supplied; pass --app-password or set \
+                 ATPROTO_APP_PASSWORD / ATPROTO_PASSWORD",
+            )?,
+    };
+
+    let http = reqwest::Client::new();
+    let url = format!("{pds_url}/xrpc/com.atproto.server.createSession");
+    let resp = http
+        .post(&url)
+        .json(&CreateSessionRequest {
+            identifier: &handle,
+            password: &password,
+        })
+        .send()
+        .await
+        .context("createSession request")?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        bail!("createSession returned {status}: {body}");
+    }
+    let resp: CreateSessionResponse = resp
+        .json()
+        .await
+        .context("decode createSession response")?;
+
+    let session = CliSession {
+        did: resp.did.clone(),
+        handle: resp.handle.or(Some(handle)),
+        pds_url,
+        access_jwt: resp.access_jwt,
+        refresh_jwt: resp.refresh_jwt,
+    };
+    let path = session.save()?;
+
+    let out = serde_json::json!({
+        "did":     session.did,
+        "handle":  session.handle,
+        "pds_url": session.pds_url,
+        "stored":  path.display().to_string(),
+    });
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(ExitCode::from(0))
+}
+
+// -----------------------------------------------------------------
+// list
+// -----------------------------------------------------------------
+
+fn cmd_list(_args: &[String]) -> Result<ExitCode> {
+    let dir = CliSession::dir()?;
+    if !dir.is_dir() {
+        println!("[]");
+        return Ok(ExitCode::from(0));
+    }
+    let mut sessions = Vec::new();
+    for entry in std::fs::read_dir(&dir).with_context(|| format!("read {}", dir.display()))? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match CliSession::load_from_path(&path) {
+            Ok(s) => sessions.push(serde_json::json!({
+                "did":     s.did,
+                "handle":  s.handle,
+                "pds_url": s.pds_url,
+            })),
+            Err(e) => {
+                eprintln!("warning: skipping {}: {e}", path.display());
+            }
+        }
+    }
+    println!("{}", serde_json::to_string_pretty(&sessions)?);
+    Ok(ExitCode::from(0))
+}
+
+impl CliSession {
+    fn load_from_path(path: &std::path::Path) -> Result<Self> {
+        let bytes = std::fs::read(path).with_context(|| format!("read {}", path.display()))?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+}
+
+// -----------------------------------------------------------------
+// logout
+// -----------------------------------------------------------------
+
+fn cmd_logout(args: &[String]) -> Result<ExitCode> {
+    let mut did: Option<String> = None;
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--did" => {
+                did = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--did requires a value"))?
+                        .clone(),
+                );
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+    let did = did.ok_or_else(|| anyhow!("--did required"))?;
+    let path = CliSession::path_for(&did)?;
+    match std::fs::remove_file(&path) {
+        Ok(()) => println!("deleted {}", path.display()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            println!("no session at {}", path.display());
+        }
+        Err(e) => return Err(e).context("delete session file"),
+    }
+    Ok(ExitCode::from(0))
+}

--- a/crates/idiolect-cli/src/oauth.rs
+++ b/crates/idiolect-cli/src/oauth.rs
@@ -64,8 +64,8 @@ impl CliSession {
     /// Load the session for `did` from disk.
     pub fn load(did: &str) -> Result<Self> {
         let path = Self::path_for(did)?;
-        let bytes = std::fs::read(&path)
-            .with_context(|| format!("read session at {}", path.display()))?;
+        let bytes =
+            std::fs::read(&path).with_context(|| format!("read session at {}", path.display()))?;
         let session: Self = serde_json::from_slice(&bytes)
             .with_context(|| format!("parse session at {}", path.display()))?;
         Ok(session)
@@ -180,10 +180,7 @@ async fn cmd_login(args: &[String]) -> Result<ExitCode> {
         let body = resp.text().await.unwrap_or_default();
         bail!("createSession returned {status}: {body}");
     }
-    let resp: CreateSessionResponse = resp
-        .json()
-        .await
-        .context("decode createSession response")?;
+    let resp: CreateSessionResponse = resp.json().await.context("decode createSession response")?;
 
     let session = CliSession {
         did: resp.did.clone(),

--- a/crates/idiolect-cli/src/publish.rs
+++ b/crates/idiolect-cli/src/publish.rs
@@ -18,8 +18,8 @@ use std::process::ExitCode;
 use anyhow::{Context, Result, anyhow, bail};
 use idiolect_records::{
     Adapter, Belief, Bounty, Community, Correction, Deliberation, DeliberationOutcome,
-    DeliberationStatement, DeliberationVote, Dialect, Encounter, Nsid, Observation, Record,
-    Recommendation, Retrospection, Verification, Vocab, decode_record,
+    DeliberationStatement, DeliberationVote, Dialect, Encounter, Nsid, Observation, Recommendation,
+    Record, Retrospection, Verification, Vocab, decode_record,
 };
 use serde::Serialize;
 
@@ -77,10 +77,9 @@ pub async fn dispatch(args: &[String]) -> Result<ExitCode> {
     // Parse + validate the record body through `decode_record`. This
     // surfaces a structured error pointing at the first invalid
     // field, before we round-trip to wire form.
-    let bytes = std::fs::read(&record_path)
-        .with_context(|| format!("read record file {record_path}"))?;
-    let value: serde_json::Value =
-        serde_json::from_slice(&bytes).context("parse record JSON")?;
+    let bytes =
+        std::fs::read(&record_path).with_context(|| format!("read record file {record_path}"))?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes).context("parse record JSON")?;
     let _any = decode_record(&nsid, value.clone()).map_err(|e| {
         anyhow!(
             "record body did not validate against {}: {e}",
@@ -191,10 +190,7 @@ fn nsid_for_kind(input: &str) -> Result<Nsid> {
     Nsid::parse(&qualified)
         .with_context(|| format!("parse NSID `{qualified}`"))
         .and_then(|n| {
-            if shipped_kinds()
-                .iter()
-                .any(|s| *s == short_name(n.as_str()))
-            {
+            if shipped_kinds().iter().any(|s| *s == short_name(n.as_str())) {
                 Ok(n)
             } else {
                 Err(anyhow!(

--- a/crates/idiolect-cli/src/publish.rs
+++ b/crates/idiolect-cli/src/publish.rs
@@ -1,0 +1,253 @@
+//! `idiolect publish` — author a record from a local JSON file.
+//!
+//! ```text
+//! idiolect publish <kind> --record <path> [--rkey RKEY] [--did DID]
+//! ```
+//!
+//! `<kind>` is the unqualified record kind (`encounter`,
+//! `recommendation`, `verification`, ...). The CLI maps it onto the
+//! corresponding `dev.idiolect.*` NSID, validates the JSON body
+//! against the typed `Record` impl, and POSTs
+//! `com.atproto.repo.createRecord` to the configured PDS using the
+//! Bearer access token saved by `idiolect oauth login`.
+//!
+//! When `--did` is omitted the CLI picks the first stored session.
+
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, anyhow, bail};
+use idiolect_records::{
+    Adapter, Belief, Bounty, Community, Correction, Deliberation, DeliberationOutcome,
+    DeliberationStatement, DeliberationVote, Dialect, Encounter, Nsid, Observation, Record,
+    Recommendation, Retrospection, Verification, Vocab, decode_record,
+};
+use serde::Serialize;
+
+use crate::oauth::CliSession;
+
+// `dispatch` does its own arg-parsing inline. Splitting it out adds
+// more shapes than it removes; allow the line-count lint here.
+#[allow(clippy::too_many_lines)]
+pub async fn dispatch(args: &[String]) -> Result<ExitCode> {
+    // First positional arg is the kind; remainder are flags.
+    let Some(kind) = args.first() else {
+        bail!(
+            "usage: idiolect publish <kind> --record <path> [--rkey RKEY] [--did DID]\n\
+             kinds: {}",
+            shipped_kinds().join(", ")
+        );
+    };
+    let rest = &args[1..];
+
+    let mut record_path: Option<String> = None;
+    let mut rkey: Option<String> = None;
+    let mut did_override: Option<String> = None;
+
+    let mut iter = rest.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--record" => {
+                record_path = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--record requires a value"))?
+                        .clone(),
+                );
+            }
+            "--rkey" => {
+                rkey = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--rkey requires a value"))?
+                        .clone(),
+                );
+            }
+            "--did" => {
+                did_override = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--did requires a value"))?
+                        .clone(),
+                );
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+    let record_path = record_path.ok_or_else(|| anyhow!("--record <path> required"))?;
+
+    let nsid = nsid_for_kind(kind)?;
+
+    // Parse + validate the record body through `decode_record`. This
+    // surfaces a structured error pointing at the first invalid
+    // field, before we round-trip to wire form.
+    let bytes = std::fs::read(&record_path)
+        .with_context(|| format!("read record file {record_path}"))?;
+    let value: serde_json::Value =
+        serde_json::from_slice(&bytes).context("parse record JSON")?;
+    let _any = decode_record(&nsid, value.clone()).map_err(|e| {
+        anyhow!(
+            "record body did not validate against {}: {e}",
+            nsid.as_str()
+        )
+    })?;
+
+    // Load the publisher session.
+    let session = match did_override {
+        Some(did) => CliSession::load(&did).with_context(|| format!("load session for {did}"))?,
+        None => first_session()?,
+    };
+
+    // Re-encode the value with a `$type` field spliced in. ATProto
+    // record bodies carry $type; the typed Rust structs don't emit
+    // one (the NSID is implicit in their type), so we add it here.
+    let mut payload = value;
+    if let serde_json::Value::Object(ref mut map) = payload {
+        map.insert(
+            "$type".to_owned(),
+            serde_json::Value::String(nsid.as_str().to_owned()),
+        );
+    } else {
+        bail!("record body must be a JSON object");
+    }
+
+    let rkey = rkey.unwrap_or_else(tid_now);
+
+    let http = reqwest::Client::new();
+    let url = format!("{}/xrpc/com.atproto.repo.createRecord", session.pds_url);
+    #[derive(Serialize)]
+    struct CreateRecordRequest<'a> {
+        repo: &'a str,
+        collection: &'a str,
+        rkey: &'a str,
+        record: serde_json::Value,
+    }
+    let response = http
+        .post(&url)
+        .bearer_auth(&session.access_jwt)
+        .json(&CreateRecordRequest {
+            repo: &session.did,
+            collection: nsid.as_str(),
+            rkey: &rkey,
+            record: payload,
+        })
+        .send()
+        .await
+        .context("createRecord request")?;
+    if !response.status().is_success() {
+        let status = response.status();
+        let body = response.text().await.unwrap_or_default();
+        bail!("createRecord returned {status}: {body}");
+    }
+
+    let envelope: serde_json::Value = response
+        .json()
+        .await
+        .context("decode createRecord response")?;
+    let uri = envelope
+        .get("uri")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?")
+        .to_owned();
+    let cid = envelope
+        .get("cid")
+        .and_then(|v| v.as_str())
+        .unwrap_or("?")
+        .to_owned();
+    let out = serde_json::json!({ "uri": uri, "cid": cid });
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(ExitCode::from(0))
+}
+
+fn shipped_kinds() -> Vec<&'static str> {
+    vec![
+        Adapter::NSID,
+        Belief::NSID,
+        Bounty::NSID,
+        Community::NSID,
+        Correction::NSID,
+        Deliberation::NSID,
+        DeliberationOutcome::NSID,
+        DeliberationStatement::NSID,
+        DeliberationVote::NSID,
+        Dialect::NSID,
+        Encounter::NSID,
+        Observation::NSID,
+        Recommendation::NSID,
+        Retrospection::NSID,
+        Verification::NSID,
+        Vocab::NSID,
+    ]
+    .into_iter()
+    .map(short_name)
+    .collect()
+}
+
+/// Accept either an unqualified kind (`encounter`) or a fully-
+/// qualified NSID (`dev.idiolect.encounter`). Return the canonical
+/// `Nsid`.
+fn nsid_for_kind(input: &str) -> Result<Nsid> {
+    let qualified = if input.contains('.') {
+        input.to_owned()
+    } else {
+        format!("dev.idiolect.{input}")
+    };
+    Nsid::parse(&qualified)
+        .with_context(|| format!("parse NSID `{qualified}`"))
+        .and_then(|n| {
+            if shipped_kinds()
+                .iter()
+                .any(|s| *s == short_name(n.as_str()))
+            {
+                Ok(n)
+            } else {
+                Err(anyhow!(
+                    "unknown kind `{input}` (try one of: {})",
+                    shipped_kinds().join(", ")
+                ))
+            }
+        })
+}
+
+fn short_name(nsid: &str) -> &str {
+    nsid.rsplit('.').next().unwrap_or(nsid)
+}
+
+fn first_session() -> Result<CliSession> {
+    let dir = CliSession::dir()?;
+    if !dir.is_dir() {
+        bail!(
+            "no session store at {} — run `idiolect oauth login` first",
+            dir.display()
+        );
+    }
+    for entry in std::fs::read_dir(&dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let bytes = std::fs::read(&path)?;
+        if let Ok(session) = serde_json::from_slice::<CliSession>(&bytes) {
+            return Ok(session);
+        }
+    }
+    bail!(
+        "no usable session in {} — run `idiolect oauth login` first",
+        dir.display()
+    )
+}
+
+/// TID-shaped rkey: milliseconds since the bsky epoch, base32 lower
+/// alphabet, 13 chars. This matches the PDS server's default rkey
+/// generator closely enough for hand-rolled publishes.
+fn tid_now() -> String {
+    const ALPHABET: &[u8] = b"234567abcdefghijklmnopqrstuvwxyz";
+    let micros = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_micros());
+    // Reserve top 2 bits for clock id; we use zero (single-host).
+    let mut n: u64 = (micros & ((1 << 53) - 1)) as u64;
+    let mut buf = [0u8; 13];
+    for byte in buf.iter_mut().rev() {
+        *byte = ALPHABET[(n & 0x1f) as usize];
+        n >>= 5;
+    }
+    String::from_utf8(buf.to_vec()).unwrap_or_else(|_| "unknown".to_owned())
+}

--- a/crates/idiolect-cli/src/util.rs
+++ b/crates/idiolect-cli/src/util.rs
@@ -24,9 +24,7 @@ pub fn now_datetime() -> Result<Datetime> {
     let hour = (time_of_day / 3600) as u32;
     let minute = ((time_of_day % 3600) / 60) as u32;
     let second = (time_of_day % 60) as u32;
-    let s = format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
-    );
+    let s = format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z");
     Datetime::parse(s).map_err(|e| anyhow!("parse datetime: {e}"))
 }
 

--- a/crates/idiolect-cli/src/util.rs
+++ b/crates/idiolect-cli/src/util.rs
@@ -1,0 +1,63 @@
+//! Shared helpers for CLI subcommands.
+
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use anyhow::{Context, Result, anyhow};
+use idiolect_records::Datetime;
+
+/// Best-effort "now" as a `Datetime`. Manual Gregorian split avoids
+/// pulling a date crate; precision is millisecond.
+pub fn now_datetime() -> Result<Datetime> {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let now = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .context("clock before unix epoch")?;
+    let secs = now.as_secs() as i64;
+    let millis = now.subsec_millis();
+    let days = secs.div_euclid(86_400);
+    let time_of_day = secs.rem_euclid(86_400);
+    let (year, month, day) = days_to_ymd(days);
+    let hour = (time_of_day / 3600) as u32;
+    let minute = ((time_of_day % 3600) / 60) as u32;
+    let second = (time_of_day % 60) as u32;
+    let s = format!(
+        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
+    );
+    Datetime::parse(s).map_err(|e| anyhow!("parse datetime: {e}"))
+}
+
+fn days_to_ymd(days: i64) -> (i64, u32, u32) {
+    let mut year: i64 = 1970;
+    let mut remaining = days;
+    loop {
+        let len = if is_leap(year) { 366 } else { 365 };
+        if remaining < len {
+            break;
+        }
+        remaining -= len;
+        year += 1;
+    }
+    let lengths = if is_leap(year) {
+        [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    } else {
+        [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    };
+    let mut month: u32 = 0;
+    for (idx, &len) in lengths.iter().enumerate() {
+        if remaining < len {
+            month = (idx + 1) as u32;
+            break;
+        }
+        remaining -= len;
+    }
+    let day = (remaining + 1) as u32;
+    (year, month, day)
+}
+
+const fn is_leap(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}

--- a/crates/idiolect-cli/src/verify.rs
+++ b/crates/idiolect-cli/src/verify.rs
@@ -116,18 +116,23 @@ fn target_from(pds: &PdsFlags) -> Result<VerificationTarget> {
             cid: None,
             direction: None,
         },
-        verifier: pds
-            .verifier_did
-            .parse()
-            .context("parse --verifier-did")?,
+        verifier: pds.verifier_did.parse().context("parse --verifier-did")?,
         occurred_at: now_datetime()?,
         tool_override: None,
     })
 }
 
-fn pds_resolver_loader(pds_url: &str) -> (PdsResolver<ReqwestPdsClient>, PdsSchemaLoader<ReqwestPdsClient>) {
+fn pds_resolver_loader(
+    pds_url: &str,
+) -> (
+    PdsResolver<ReqwestPdsClient>,
+    PdsSchemaLoader<ReqwestPdsClient>,
+) {
     let client = ReqwestPdsClient::with_service_url(pds_url);
-    (PdsResolver::new(client.clone()), PdsSchemaLoader::new(client))
+    (
+        PdsResolver::new(client.clone()),
+        PdsSchemaLoader::new(client),
+    )
 }
 
 fn print_and_exit(verification: &Verification) -> Result<ExitCode> {
@@ -145,8 +150,7 @@ fn print_and_exit(verification: &Verification) -> Result<ExitCode> {
 /// or JSON Lines (one record per line).
 fn load_corpus(path: &str) -> Result<Vec<serde_json::Value>> {
     let bytes = std::fs::read(path).with_context(|| format!("read corpus {path}"))?;
-    if let Ok(serde_json::Value::Array(items)) =
-        serde_json::from_slice::<serde_json::Value>(&bytes)
+    if let Ok(serde_json::Value::Array(items)) = serde_json::from_slice::<serde_json::Value>(&bytes)
     {
         return Ok(items);
     }

--- a/crates/idiolect-cli/src/verify.rs
+++ b/crates/idiolect-cli/src/verify.rs
@@ -1,0 +1,411 @@
+//! `idiolect verify` — run a shipped verification runner.
+//!
+//! ```text
+//! idiolect verify roundtrip-test       --lens AT_URI [--corpus PATH]   [--pds-url URL] [--verifier-did DID]
+//! idiolect verify property-test        --lens AT_URI  --corpus PATH    [--budget N]    [--pds-url URL] [--verifier-did DID]
+//! idiolect verify static-check         --lens AT_URI                   [--pds-url URL] [--verifier-did DID]
+//! idiolect verify coercion-law         --lens AT_URI  --vcs-url URL    --standard STD  [--version V] [--violation-threshold N] [--verifier-did DID]
+//! ```
+//!
+//! Wraps each shipped `VerificationRunner` for command-line use.
+//! Prints the resulting `Verification` record as JSON; falsifying /
+//! inconclusive runs exit with a non-zero status so CI surfaces them.
+
+#![allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, anyhow, bail};
+use idiolect_lens::{LensError, PdsResolver, PdsSchemaLoader, ReqwestPdsClient};
+use idiolect_records::generated::dev::idiolect::defs::LensRef;
+use idiolect_records::generated::dev::idiolect::verification::{Verification, VerificationResult};
+use idiolect_verify::{
+    CoercionLawClient, CoercionLawRunner, CoercionLawViolation, PropertyTestRunner,
+    RoundtripTestRunner, StaticCheckRunner, VerificationRunner, VerificationTarget,
+};
+use panproto_schema::Protocol;
+use serde::Serialize;
+
+use crate::util::now_datetime;
+
+const DEFAULT_PDS_URL: &str = "https://jellybaby.us-east.host.bsky.network";
+const DEFAULT_PROPERTY_BUDGET: u32 = 100;
+
+pub async fn dispatch(args: &[String]) -> Result<ExitCode> {
+    let Some(kind) = args.first() else {
+        bail!(
+            "usage: idiolect verify <kind> [flags]\n\
+             kinds: roundtrip-test | property-test | static-check | coercion-law"
+        );
+    };
+    let rest = &args[1..];
+    match kind.as_str() {
+        "roundtrip-test" => cmd_roundtrip(rest).await,
+        "property-test" => cmd_property_test(rest).await,
+        "static-check" => cmd_static_check(rest).await,
+        "coercion-law" => cmd_coercion_law(rest).await,
+        other => bail!(
+            "unknown verify kind: {other}\n\
+             kinds: roundtrip-test | property-test | static-check | coercion-law"
+        ),
+    }
+}
+
+// -----------------------------------------------------------------
+// shared
+// -----------------------------------------------------------------
+
+/// Common flag set for runners that talk to a PDS.
+struct PdsFlags {
+    lens: String,
+    pds_url: String,
+    verifier_did: String,
+}
+
+fn parse_pds_flags(args: &[String]) -> Result<(PdsFlags, Vec<String>)> {
+    let mut lens: Option<String> = None;
+    let mut pds_url = DEFAULT_PDS_URL.to_owned();
+    let mut verifier_did = "did:plc:unknown".to_owned();
+    let mut leftover = Vec::new();
+
+    let mut iter = args.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--lens" | "--lens_uri" => {
+                lens = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--lens requires a value"))?
+                        .clone(),
+                );
+            }
+            "--pds-url" => {
+                pds_url.clone_from(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--pds-url requires a value"))?,
+                );
+            }
+            "--verifier-did" => {
+                verifier_did.clone_from(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--verifier-did requires a value"))?,
+                );
+            }
+            other => {
+                leftover.push(other.to_owned());
+                if let Some(value) = iter.next() {
+                    leftover.push(value.clone());
+                }
+            }
+        }
+    }
+    let lens = lens.ok_or_else(|| anyhow!("--lens <at-uri> required"))?;
+    Ok((
+        PdsFlags {
+            lens,
+            pds_url,
+            verifier_did,
+        },
+        leftover,
+    ))
+}
+
+fn target_from(pds: &PdsFlags) -> Result<VerificationTarget> {
+    Ok(VerificationTarget {
+        lens: LensRef {
+            uri: Some(pds.lens.parse().context("parse --lens at-uri")?),
+            cid: None,
+            direction: None,
+        },
+        verifier: pds
+            .verifier_did
+            .parse()
+            .context("parse --verifier-did")?,
+        occurred_at: now_datetime()?,
+        tool_override: None,
+    })
+}
+
+fn pds_resolver_loader(pds_url: &str) -> (PdsResolver<ReqwestPdsClient>, PdsSchemaLoader<ReqwestPdsClient>) {
+    let client = ReqwestPdsClient::with_service_url(pds_url);
+    (PdsResolver::new(client.clone()), PdsSchemaLoader::new(client))
+}
+
+fn print_and_exit(verification: &Verification) -> Result<ExitCode> {
+    let json = serde_json::to_string_pretty(verification)?;
+    println!("{json}");
+    Ok(match verification.result {
+        VerificationResult::Holds => ExitCode::from(0),
+        VerificationResult::Falsified
+        | VerificationResult::Inconclusive
+        | VerificationResult::Other(_) => ExitCode::from(1),
+    })
+}
+
+/// Read a corpus file. The file may be a JSON array of record bodies
+/// or JSON Lines (one record per line).
+fn load_corpus(path: &str) -> Result<Vec<serde_json::Value>> {
+    let bytes = std::fs::read(path).with_context(|| format!("read corpus {path}"))?;
+    if let Ok(serde_json::Value::Array(items)) =
+        serde_json::from_slice::<serde_json::Value>(&bytes)
+    {
+        return Ok(items);
+    }
+    let mut items = Vec::new();
+    for (i, line) in std::str::from_utf8(&bytes)
+        .context("corpus is not UTF-8")?
+        .lines()
+        .enumerate()
+    {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        let value: serde_json::Value = serde_json::from_str(trimmed)
+            .with_context(|| format!("parse corpus line {}", i + 1))?;
+        items.push(value);
+    }
+    if items.is_empty() {
+        bail!("corpus at {path} parsed to zero records");
+    }
+    Ok(items)
+}
+
+// -----------------------------------------------------------------
+// roundtrip-test
+// -----------------------------------------------------------------
+
+async fn cmd_roundtrip(args: &[String]) -> Result<ExitCode> {
+    let (pds, rest) = parse_pds_flags(args)?;
+    let mut corpus_path: Option<String> = None;
+    let mut iter = rest.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--corpus" => {
+                corpus_path = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--corpus requires a value"))?
+                        .clone(),
+                );
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+    let corpus = match corpus_path.as_deref() {
+        Some(p) => load_corpus(p)?,
+        None => vec![serde_json::json!({ "text": "" })],
+    };
+    let (resolver, loader) = pds_resolver_loader(&pds.pds_url);
+    let runner = RoundtripTestRunner::new(resolver, loader, Protocol::default(), corpus);
+    let target = target_from(&pds)?;
+    let verification = runner
+        .run(&target)
+        .await
+        .context("RoundtripTestRunner::run")?;
+    print_and_exit(&verification)
+}
+
+// -----------------------------------------------------------------
+// property-test
+// -----------------------------------------------------------------
+
+async fn cmd_property_test(args: &[String]) -> Result<ExitCode> {
+    let (pds, rest) = parse_pds_flags(args)?;
+    let mut corpus_path: Option<String> = None;
+    let mut budget = DEFAULT_PROPERTY_BUDGET;
+    let mut iter = rest.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--corpus" => {
+                corpus_path = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--corpus requires a value"))?
+                        .clone(),
+                );
+            }
+            "--budget" => {
+                budget = iter
+                    .next()
+                    .ok_or_else(|| anyhow!("--budget requires a value"))?
+                    .parse()
+                    .context("parse --budget")?;
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+    let corpus = load_corpus(corpus_path.as_deref().ok_or_else(|| {
+        anyhow!("--corpus <path> required for property-test (drives the generator)")
+    })?)?;
+
+    let (resolver, loader) = pds_resolver_loader(&pds.pds_url);
+    // Generator returns corpus[idx % len] for the i-th case, so the
+    // CLI's "corpus file" doubles as a generator pool.
+    let corpus_clone = corpus.clone();
+    let runner = PropertyTestRunner::new(
+        resolver,
+        loader,
+        Protocol::default(),
+        budget,
+        move |idx: u32| corpus_clone[(idx as usize) % corpus_clone.len()].clone(),
+    );
+    let target = target_from(&pds)?;
+    let verification = runner
+        .run(&target)
+        .await
+        .context("PropertyTestRunner::run")?;
+    print_and_exit(&verification)
+}
+
+// -----------------------------------------------------------------
+// static-check
+// -----------------------------------------------------------------
+
+async fn cmd_static_check(args: &[String]) -> Result<ExitCode> {
+    let (pds, rest) = parse_pds_flags(args)?;
+    if let Some(flag) = rest.first() {
+        bail!("unknown flag: {flag}");
+    }
+    let (resolver, loader) = pds_resolver_loader(&pds.pds_url);
+    let runner = StaticCheckRunner::new(resolver, loader, Protocol::default());
+    let target = target_from(&pds)?;
+    let verification = runner
+        .run(&target)
+        .await
+        .context("StaticCheckRunner::run")?;
+    print_and_exit(&verification)
+}
+
+// -----------------------------------------------------------------
+// coercion-law
+// -----------------------------------------------------------------
+
+/// Reqwest-backed `CoercionLawClient` calling the
+/// `dev.panproto.translate.verifyCoercionLaws` xrpc method on a
+/// panproto-vcs endpoint.
+struct ReqwestCoercionLawClient {
+    http: reqwest::Client,
+    vcs_url: String,
+}
+
+#[derive(Serialize)]
+struct VerifyCoercionRequest<'a> {
+    lens: &'a str,
+    standard: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    version: Option<&'a str>,
+}
+
+impl CoercionLawClient for ReqwestCoercionLawClient {
+    async fn verify_coercion_laws(
+        &self,
+        lens_uri: &str,
+        standard: &str,
+        version: Option<&str>,
+    ) -> Result<Vec<CoercionLawViolation>, LensError> {
+        let url = format!(
+            "{}/xrpc/dev.panproto.translate.verifyCoercionLaws",
+            self.vcs_url
+        );
+        let resp = self
+            .http
+            .post(&url)
+            .json(&VerifyCoercionRequest {
+                lens: lens_uri,
+                standard,
+                version,
+            })
+            .send()
+            .await
+            .map_err(|e| LensError::Transport(format!("verifyCoercionLaws: {e}")))?;
+        let status = resp.status();
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| LensError::Transport(format!("verifyCoercionLaws body: {e}")))?;
+        if !status.is_success() {
+            return Err(LensError::Transport(format!(
+                "verifyCoercionLaws returned {status}: {body}"
+            )));
+        }
+        let raw = body
+            .get("violations")
+            .cloned()
+            .unwrap_or(serde_json::Value::Array(vec![]));
+        let entries: Vec<serde_json::Value> = serde_json::from_value(raw)
+            .map_err(|e| LensError::Transport(format!("decode violations: {e}")))?;
+        Ok(entries
+            .into_iter()
+            .map(|v| CoercionLawViolation {
+                law: v
+                    .get("law")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_owned(),
+                detail: v
+                    .get("detail")
+                    .and_then(|s| s.as_str())
+                    .unwrap_or("")
+                    .to_owned(),
+            })
+            .collect())
+    }
+}
+
+async fn cmd_coercion_law(args: &[String]) -> Result<ExitCode> {
+    let (pds, rest) = parse_pds_flags(args)?;
+    let mut vcs_url: Option<String> = None;
+    let mut standard: Option<String> = None;
+    let mut version: Option<String> = None;
+    let mut violation_threshold: Option<u32> = None;
+    let mut iter = rest.iter();
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--vcs-url" => {
+                vcs_url = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--vcs-url requires a value"))?
+                        .clone(),
+                );
+            }
+            "--standard" => {
+                standard = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--standard requires a value"))?
+                        .clone(),
+                );
+            }
+            "--version" => {
+                version = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--version requires a value"))?
+                        .clone(),
+                );
+            }
+            "--violation-threshold" => {
+                violation_threshold = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--violation-threshold requires a value"))?
+                        .parse()
+                        .context("parse --violation-threshold")?,
+                );
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+    let vcs_url = vcs_url.ok_or_else(|| anyhow!("--vcs-url required"))?;
+    let standard = standard.ok_or_else(|| anyhow!("--standard required"))?;
+
+    let client = ReqwestCoercionLawClient {
+        http: reqwest::Client::new(),
+        vcs_url,
+    };
+    let runner = CoercionLawRunner::new(client, standard, version, violation_threshold);
+    let target = target_from(&pds)?;
+    let verification = runner
+        .run(&target)
+        .await
+        .context("CoercionLawRunner::run")?;
+    // pds is unused here (coercion-law uses a vcs URL); silence the
+    // borrow-checker by referencing pds_url anyway.
+    let _ = pds.pds_url;
+    print_and_exit(&verification)
+}

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.9.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.10.0", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.9.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.10.0", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.9.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.10.0", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.9.0", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.10.0", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -17,9 +17,27 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+default = []
+# `idiolect-migrate` binary: streaming batch migration from a
+# directory of JSON records through a lens at-uri, against a live
+# PDS. Pulls in tokio + reqwest + the lens crate's PDS-reqwest
+# transport.
+cli = [
+    "dep:anyhow",
+    "dep:tokio",
+    "dep:tracing-subscriber",
+    "idiolect-lens/pds-reqwest",
+]
+
+[[bin]]
+name = "idiolect-migrate"
+path = "src/bin/idiolect_migrate.rs"
+required-features = ["cli"]
+
 [dependencies]
-idiolect-records = { version = "0.9.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.9.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.10.0", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.10.0", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }
@@ -31,6 +49,10 @@ serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }
 tracing    = "0.1"
+
+anyhow             = { version = "1", optional = true }
+tokio              = { version = "1.48", default-features = false, features = ["macros", "rt-multi-thread"], optional = true }
+tracing-subscriber = { version = "0.3", features = ["env-filter"], optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.48", default-features = false, features = ["macros", "rt"] }

--- a/crates/idiolect-migrate/src/bin/idiolect_migrate.rs
+++ b/crates/idiolect-migrate/src/bin/idiolect_migrate.rs
@@ -49,13 +49,22 @@ async fn run() -> Result<ExitCode> {
     while let Some(flag) = iter.next() {
         match flag.as_str() {
             "--lens" => {
-                lens_uri = Some(iter.next().ok_or_else(|| anyhow!("--lens requires a value"))?);
+                lens_uri = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--lens requires a value"))?,
+                );
             }
             "--in" => {
-                in_dir = Some(iter.next().ok_or_else(|| anyhow!("--in requires a value"))?);
+                in_dir = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--in requires a value"))?,
+                );
             }
             "--out" => {
-                out_dir = Some(iter.next().ok_or_else(|| anyhow!("--out requires a value"))?);
+                out_dir = Some(
+                    iter.next()
+                        .ok_or_else(|| anyhow!("--out requires a value"))?,
+                );
             }
             "--pds-url" => {
                 pds_url = iter
@@ -83,8 +92,7 @@ async fn run() -> Result<ExitCode> {
 
     let mut ok: u32 = 0;
     let mut failed: u32 = 0;
-    for entry in std::fs::read_dir(&in_dir).with_context(|| format!("read {}", in_dir.display()))?
-    {
+    for entry in std::fs::read_dir(&in_dir).with_context(|| format!("read {}", in_dir.display()))? {
         let entry = entry?;
         let path = entry.path();
         if path.extension().and_then(|e| e.to_str()) != Some("json") {

--- a/crates/idiolect-migrate/src/bin/idiolect_migrate.rs
+++ b/crates/idiolect-migrate/src/bin/idiolect_migrate.rs
@@ -1,0 +1,149 @@
+//! `idiolect-migrate` — streaming batch migration of JSON records
+//! through a published lens.
+//!
+//! ```text
+//! idiolect-migrate \
+//!     --lens   AT_URI \
+//!     --in     SOURCE_DIR \
+//!     --out    TARGET_DIR \
+//!    [--pds-url URL]
+//! ```
+//!
+//! Walks every `*.json` file under `SOURCE_DIR`, runs each through
+//! `migrate_record` against the live PDS, and writes the result to
+//! `TARGET_DIR/<same-name>.json`. Files that fail migration are
+//! logged to stderr and skipped; the binary's exit code reflects
+//! the worst case (0 if everything succeeded, 1 if any file failed).
+//!
+//! The working set stays bounded: records stream one at a time.
+
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::{Context, Result, anyhow, bail};
+use idiolect_lens::{PdsResolver, PdsSchemaLoader, ReqwestPdsClient};
+use idiolect_migrate::migrate_record;
+use panproto_schema::Protocol;
+
+const DEFAULT_PDS_URL: &str = "https://jellybaby.us-east.host.bsky.network";
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    init_tracing();
+    match run().await {
+        Ok(code) => code,
+        Err(err) => {
+            eprintln!("error: {err:#}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+async fn run() -> Result<ExitCode> {
+    let mut lens_uri: Option<String> = None;
+    let mut in_dir: Option<String> = None;
+    let mut out_dir: Option<String> = None;
+    let mut pds_url = DEFAULT_PDS_URL.to_owned();
+
+    let mut iter = std::env::args().skip(1);
+    while let Some(flag) = iter.next() {
+        match flag.as_str() {
+            "--lens" => {
+                lens_uri = Some(iter.next().ok_or_else(|| anyhow!("--lens requires a value"))?);
+            }
+            "--in" => {
+                in_dir = Some(iter.next().ok_or_else(|| anyhow!("--in requires a value"))?);
+            }
+            "--out" => {
+                out_dir = Some(iter.next().ok_or_else(|| anyhow!("--out requires a value"))?);
+            }
+            "--pds-url" => {
+                pds_url = iter
+                    .next()
+                    .ok_or_else(|| anyhow!("--pds-url requires a value"))?;
+            }
+            "--help" | "-h" => {
+                print_help();
+                return Ok(ExitCode::from(0));
+            }
+            other => bail!("unknown flag: {other}"),
+        }
+    }
+
+    let lens_uri = lens_uri.ok_or_else(|| anyhow!("--lens <at-uri> required"))?;
+    let in_dir = PathBuf::from(in_dir.ok_or_else(|| anyhow!("--in <dir> required"))?);
+    let out_dir = PathBuf::from(out_dir.ok_or_else(|| anyhow!("--out <dir> required"))?);
+
+    std::fs::create_dir_all(&out_dir).with_context(|| format!("create {}", out_dir.display()))?;
+
+    let client = ReqwestPdsClient::with_service_url(&pds_url);
+    let resolver = PdsResolver::new(client.clone());
+    let loader = PdsSchemaLoader::new(client);
+    let protocol = Protocol::default();
+
+    let mut ok: u32 = 0;
+    let mut failed: u32 = 0;
+    for entry in std::fs::read_dir(&in_dir).with_context(|| format!("read {}", in_dir.display()))?
+    {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        match migrate_one(&resolver, &loader, &protocol, &lens_uri, &path, &out_dir).await {
+            Ok(out_path) => {
+                ok += 1;
+                eprintln!("ok    {} -> {}", path.display(), out_path.display());
+            }
+            Err(e) => {
+                failed += 1;
+                eprintln!("fail  {}: {e:#}", path.display());
+            }
+        }
+    }
+    eprintln!("\n{ok} succeeded, {failed} failed");
+    Ok(if failed == 0 {
+        ExitCode::from(0)
+    } else {
+        ExitCode::from(1)
+    })
+}
+
+async fn migrate_one(
+    resolver: &PdsResolver<ReqwestPdsClient>,
+    loader: &PdsSchemaLoader<ReqwestPdsClient>,
+    protocol: &Protocol,
+    lens_uri: &str,
+    src_path: &Path,
+    out_dir: &Path,
+) -> Result<PathBuf> {
+    let bytes = std::fs::read(src_path)?;
+    let value: serde_json::Value = serde_json::from_slice(&bytes)?;
+    let migrated = migrate_record(resolver, loader, protocol, lens_uri, value).await?;
+    let file_name = src_path
+        .file_name()
+        .ok_or_else(|| anyhow!("no filename component"))?;
+    let out_path = out_dir.join(file_name);
+    let out_bytes = serde_json::to_vec_pretty(&migrated)?;
+    std::fs::write(&out_path, out_bytes)?;
+    Ok(out_path)
+}
+
+fn print_help() {
+    println!(
+        "idiolect-migrate {}\n\n\
+         streaming batch migration of JSON records through a lens.\n\n\
+         usage:\n  \
+         idiolect-migrate --lens AT_URI --in SOURCE_DIR --out TARGET_DIR [--pds-url URL]",
+        env!("CARGO_PKG_VERSION")
+    );
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .try_init();
+}

--- a/crates/idiolect-oauth/src/lib.rs
+++ b/crates/idiolect-oauth/src/lib.rs
@@ -81,6 +81,7 @@
 //! # }
 //! ```
 
+pub mod refresh;
 pub mod schema;
 pub mod session;
 pub mod store;
@@ -90,6 +91,7 @@ pub mod store_fs;
 #[cfg(feature = "store-sqlite")]
 pub mod store_sqlite;
 
+pub use refresh::{DEFAULT_REFRESH_THRESHOLD_SECS, RefreshError, Refresher, refresh_if_needed};
 pub use schema::{
     SESSION_LEXICON_JSON, SESSION_NSID, SchemaError, session_body_vertex, session_schema,
 };

--- a/crates/idiolect-oauth/src/refresh.rs
+++ b/crates/idiolect-oauth/src/refresh.rs
@@ -1,0 +1,89 @@
+//! `refresh_if_needed` — the standard "look up a session, refresh if
+//! the access token is past expiry, persist the refreshed value, hand
+//! the live session back" helper.
+//!
+//! The refresh HTTP call itself lives in `atrium-oauth-client`; this
+//! module owns the storage and timing decision around it. Callers
+//! who want to drive their own refresh path read
+//! [`OAuthSession::needs_refresh`] / [`OAuthSession::is_expired`]
+//! directly.
+
+use crate::session::{OAuthSession, SessionError};
+use crate::store::{OAuthTokenStore, StoreError};
+
+/// Wall-clock minus this many seconds is the "now" threshold for the
+/// refresh decision: if the access token's `expires_at` is within
+/// this window we refresh ahead of actual expiry. Sixty seconds is
+/// a reasonable buffer against clock skew and in-flight requests.
+pub const DEFAULT_REFRESH_THRESHOLD_SECS: i64 = 60;
+
+/// Error surface for [`refresh_if_needed`]. Boxes the per-source
+/// errors so callers can match without naming every source crate.
+#[derive(Debug, thiserror::Error)]
+pub enum RefreshError {
+    /// The token store failed reading or writing the session.
+    #[error("session store error: {0}")]
+    Store(#[from] StoreError),
+    /// The stored session was malformed (corrupt expiry timestamp,
+    /// missing fields).
+    #[error("session shape error: {0}")]
+    Session(#[from] SessionError),
+    /// No session is stored for the given `did`.
+    #[error("no session stored for {0}")]
+    NoSession(String),
+    /// The caller-supplied refresh closure failed.
+    #[error("refresh callback failed: {0}")]
+    Callback(String),
+}
+
+/// Trait the caller implements to perform the actual refresh against
+/// whatever transport (atrium-oauth-client, hand-rolled reqwest,
+/// in-memory fake for tests) it has on hand.
+///
+/// Kept narrow so the `idiolect-oauth` crate stays
+/// transport-agnostic. Concrete impls live in `idiolect-cli` or
+/// downstream consumers.
+#[allow(async_fn_in_trait)]
+pub trait Refresher: Send + Sync {
+    /// Given an expired session, return a fresh one with new
+    /// `access_jwt`, `expires_at`, and (usually) `refresh_jwt`.
+    async fn refresh(&self, session: &OAuthSession) -> Result<OAuthSession, RefreshError>;
+}
+
+/// Look up the session for `did`, decide whether it needs to refresh
+/// based on the current wall clock plus a 60-second buffer, drive
+/// `refresher` if so, persist the result, and return the live
+/// session.
+///
+/// `store` is the persistence boundary; `refresher` is the transport.
+///
+/// # Errors
+///
+/// [`RefreshError::NoSession`] when no session is stored for the
+/// DID; [`RefreshError::Store`] on backing-store failures;
+/// [`RefreshError::Callback`] when the refresher's HTTP call fails;
+/// [`RefreshError::Session`] when the stored session's timestamps
+/// are malformed.
+pub async fn refresh_if_needed<S, R>(
+    store: &S,
+    refresher: &R,
+    did: &str,
+) -> Result<OAuthSession, RefreshError>
+where
+    S: OAuthTokenStore,
+    R: Refresher,
+{
+    let Some(session) = store.load(did).await? else {
+        return Err(RefreshError::NoSession(did.to_owned()));
+    };
+
+    let now = time::OffsetDateTime::now_utc();
+    let threshold = time::Duration::seconds(DEFAULT_REFRESH_THRESHOLD_SECS);
+    if !session.needs_refresh(now, threshold) {
+        return Ok(session);
+    }
+
+    let updated = refresher.refresh(&session).await?;
+    store.save(&updated).await?;
+    Ok(updated)
+}

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.9.0", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.9.0", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.10.0", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.10.0", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.9.0", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.10.0", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-observer/src/generated.rs
+++ b/crates/idiolect-observer/src/generated.rs
@@ -78,6 +78,12 @@ pub const METHODS: &[MethodDescriptor] = &[
         description: "Counts of dev.idiolect.belief records by holder DID and by subject at-uri. Surfaces labeler coverage over the firehose and records that attract many third-party attributions.",
         form: MethodForm::Record,
     },
+    MethodDescriptor {
+        name: crate::methods::deliberation_tally::METHOD_NAME,
+        version: crate::methods::deliberation_tally::METHOD_VERSION,
+        description: "Per-statement per-stance vote counts across dev.idiolect.deliberationVote records. The data shape a dev.idiolect.deliberationOutcome record carries, emitted as an observation for visibility into in-progress deliberations.",
+        form: MethodForm::Record,
+    },
 ];
 /// Fresh instances of every bundled record-form method, in spec order.
 ///
@@ -96,5 +102,6 @@ pub fn default_methods() -> Vec<Box<dyn crate::method::ObservationMethod>> {
         Box::new(crate::methods::purpose_distribution::PurposeDistributionMethod::new()),
         Box::new(crate::methods::basis_distribution::BasisDistributionMethod::new()),
         Box::new(crate::methods::attribution_chains::AttributionChainsMethod::new()),
+        Box::new(crate::methods::deliberation_tally::DeliberationTallyMethod::new()),
     ]
 }

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.9.0", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.9.0", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.10.0", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.10.0", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.9.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.9.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.10.0", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.10.0", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/docs/book/src/guide/migrate.md
+++ b/docs/book/src/guide/migrate.md
@@ -122,10 +122,22 @@ covers that case. The authoring loop is:
 Each step is mechanical and gated; the policy is what makes
 migrations reviewable.
 
-## What is not in this crate
+## Batch migration
 
-A streaming batch CLI that takes a directory of records and
-writes a migrated directory is not currently shipped. Callers
-that want one wire `migrate_record` into their own loop. The
-shape is small enough that a per-deployment script is usually
-the right answer.
+The crate ships an `idiolect-migrate` binary (behind the `cli`
+feature) that walks a directory of JSON records and writes a
+migrated directory:
+
+```bash
+cargo install --path crates/idiolect-migrate --features cli
+idiolect-migrate \
+    --lens   at://did:plc:.../dev.panproto.schema.lens/example \
+    --in     ./records-v1/ \
+    --out    ./records-v2/ \
+   [--pds-url URL]
+```
+
+Records stream one at a time so the working set stays bounded
+even on multi-million-record corpora. Failed migrations log to
+stderr and the binary's exit code reflects the worst case (0 if
+every file succeeded, 1 if any failed).

--- a/docs/book/src/guide/oauth.md
+++ b/docs/book/src/guide/oauth.md
@@ -88,15 +88,57 @@ Both shipped persistent stores
 (`FilesystemOAuthTokenStore`, `SqliteOAuthTokenStore`) do; if
 you write a custom store, do the same.
 
-## Planned functionality
+## `idiolect oauth login` (transitional)
 
-- An `idiolect oauth login --handle <HANDLE>` CLI subcommand
-  driving the OAuth dance via `atrium-oauth-client` and
-  persisting the resulting session through the configured
-  `OAuthTokenStore`. Not shipped at v0.8.0; the dance is
-  programmatic.
-- A `refresh_if_needed(store, did)` helper that wraps the
-  refresh-on-expiry pattern. Not shipped at v0.8.0; the
-  primitives (`is_expired`, `needs_refresh`,
-  `refresh_expired`) are exposed and applications drive the
-  refresh call themselves.
+The `idiolect` CLI ships an `oauth login` subcommand that
+exchanges a handle + app password for an access JWT via
+`com.atproto.server.createSession` and persists the resulting
+session as a JSON file under
+`$IDIOLECT_SESSION_DIR` (default
+`~/.config/idiolect/sessions/`):
+
+```bash
+idiolect oauth login --handle yourhandle.bsky.social --pds-url https://bsky.social
+# password from --app-password or ATPROTO_APP_PASSWORD / ATPROTO_PASSWORD env
+idiolect oauth list
+idiolect oauth logout --did did:plc:...
+```
+
+This path uses **app passwords in legacy Bearer mode**.
+ATProto is moving off app passwords in favour of OAuth +
+DPoP; the next-iteration login UX wraps `atrium-oauth`'s
+browser-handoff dance and persists the resulting DPoP-bound
+session through the same `OAuthTokenStore`. The `OAuthSession`
+shape already carries the DPoP private key field; switching
+flows is a CLI substitution, not a session-shape change.
+
+## `refresh_if_needed`
+
+`idiolect_oauth::refresh_if_needed(&store, &refresher, did)`
+loads a session, decides whether to refresh based on the
+current wall clock plus a 60-second buffer, drives the caller-
+supplied `Refresher::refresh` if so, persists the result, and
+returns the live session. Callers who want to drive the
+decision themselves read `OAuthSession::needs_refresh` and
+`OAuthSession::is_expired` directly.
+
+```rust
+use idiolect_oauth::{refresh_if_needed, Refresher, RefreshError, OAuthSession};
+
+struct MyRefresher { /* http client, auth-server URL, ... */ }
+
+impl Refresher for MyRefresher {
+    async fn refresh(&self, session: &OAuthSession) -> Result<OAuthSession, RefreshError> {
+        // POST refresh_token to the auth-server's token_endpoint.
+        // Return a fresh OAuthSession with new access_jwt / expires_at.
+        todo!()
+    }
+}
+
+let fresh = refresh_if_needed(&store, &MyRefresher { /* ... */ }, "did:plc:...").await?;
+```
+
+The trait is narrow on purpose: the refresh HTTP call lives in
+whatever OAuth client the application uses (atrium-oauth, a
+hand-rolled reqwest call, an in-memory fake for tests).
+`idiolect-oauth` owns the storage and timing decision around it.

--- a/docs/book/src/guide/observer.md
+++ b/docs/book/src/guide/observer.md
@@ -98,10 +98,12 @@ to the `default_methods()` constructor.
   of $n$ trusted observers before treating an observation as
   authoritative.
 
-## What is not currently shipped
+## Note on `deliberation-tally`
 
-A `deliberation-tally` method that produces
-`dev.idiolect.deliberationOutcome` records is not in the
-shipped method set. Communities that need a Polis-style tally
-of a deliberation author the method against the same
-`ObservationMethod` trait or build it as a downstream daemon.
+The shipped `deliberation-tally` method emits its
+per-statement per-stance vote counts inside an
+`observation.output` blob, not as a typed
+`dev.idiolect.deliberationOutcome` record. The data shape is
+the same; the surface differs. A variant that publishes the
+typed outcome record directly is a small refactor on top of
+the existing `DeliberationTallyMethod`.

--- a/docs/book/src/guide/verify.md
+++ b/docs/book/src/guide/verify.md
@@ -85,12 +85,21 @@ and forwards to the configured `PdsWriter`. The signing path
 goes through `SigningPdsWriter` plus a `DpopProver` from the
 `pds-reqwest` and (optionally) `dpop-p256` features.
 
-## Planned functionality
+## CLI surface
 
-- An `idiolect verify <kind>` CLI subcommand that runs any
-  shipped `VerificationRunner` and publishes the result via
-  `RecordPublisher`. Not shipped at v0.8.0; runners are
-  library-only.
-- A bundled corpus loader. Each shipped runner takes whatever
-  target shape it needs; a unified corpus-loading API across
-  runners is plausible future work, not shipped at v0.8.0.
+The `idiolect verify <kind>` subcommand wraps each shipped
+runner against a live PDS via `PdsResolver` + `PdsSchemaLoader`:
+
+```text
+idiolect verify roundtrip-test  --lens AT_URI [--corpus PATH]
+idiolect verify property-test   --lens AT_URI  --corpus PATH  [--budget N]
+idiolect verify static-check    --lens AT_URI
+idiolect verify coercion-law    --lens AT_URI  --vcs-url URL  --standard STD
+```
+
+Corpus files may be JSON arrays or JSON Lines. The
+`property-test` generator cycles through the corpus by index;
+`--budget` controls case count. The CLI prints the typed
+`Verification` record as JSON and exits non-zero on `Falsified`
+or `Inconclusive`. Publishing the result is a separate step;
+pipe to `idiolect publish verification --record -`.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -9,15 +9,18 @@ idiolect resolve <did>
 idiolect fetch <at-uri>
 idiolect orchestrator <subcommand>
 idiolect encounter record [...]
+idiolect oauth login | list | logout [...]
+idiolect publish <kind> --record <path> [...]
+idiolect verify <kind> [...]
 idiolect version          # also accepts --version, -V
 idiolect help [<sub>]     # also accepts --help, -h
 ```
 
-The two hand-written subcommands (`resolve`, `fetch`) live in
-`main.rs` and call directly into `idiolect-identity` and
-`idiolect-lens`. The `orchestrator` subcommand is generated
-from `orchestrator-spec/queries.json` and routes its calls to
-the orchestrator's HTTP API.
+The hand-written subcommands (`resolve`, `fetch`, `oauth`,
+`publish`, `verify`, `encounter`) live in their own modules
+under `crates/idiolect-cli/src/`. The `orchestrator` subcommand
+is generated from `orchestrator-spec/queries.json` and routes
+its calls to the orchestrator's HTTP API.
 
 ## `resolve`
 
@@ -61,6 +64,68 @@ Adding a query to the spec extends both the HTTP and the CLI
 surface; see [Run codegen](../guide/codegen.md). The CLI's
 top-level `--url` flag overrides the default orchestrator base.
 
+## `oauth`
+
+Authenticated PDS sessions for `idiolect publish` and downstream
+record-writing flows.
+
+```text
+idiolect oauth login  --handle HANDLE --app-password PASSWORD [--pds-url URL]
+idiolect oauth list
+idiolect oauth logout --did DID
+```
+
+`login` exchanges `(handle, app-password)` for an access JWT via
+`com.atproto.server.createSession` and persists `{did, handle,
+pds_url, access_jwt, refresh_jwt}` as one JSON file per DID
+under `$IDIOLECT_SESSION_DIR` (default
+`~/.config/idiolect/sessions/`). `--app-password` may be passed
+as a flag or via `ATPROTO_APP_PASSWORD` / `ATPROTO_PASSWORD`
+env vars to avoid leaking into shell history.
+
+`list` enumerates every stored session as a JSON array of
+`{did, handle, pds_url}` triples.
+
+`logout` deletes the session file for `--did`; a missing file is
+not an error.
+
+## `publish <kind>`
+
+```text
+idiolect publish <kind> --record <path> [--rkey RKEY] [--did DID]
+```
+
+Loads a JSON file, validates it against the typed `Record` impl
+for `<kind>` (which can be either the unqualified kind like
+`recommendation` or the fully-qualified NSID like
+`dev.idiolect.recommendation`), splices in a `$type`
+discriminator, and POSTs `com.atproto.repo.createRecord` using
+the stored session's bearer auth.
+
+When `--did` is omitted the CLI picks the first stored session.
+When `--rkey` is omitted the CLI generates a TID-shaped key.
+
+Prints `{uri, cid}` of the published record on success.
+
+## `verify <kind>`
+
+```text
+idiolect verify roundtrip-test  --lens AT_URI [--corpus PATH]   [--pds-url URL] [--verifier-did DID]
+idiolect verify property-test   --lens AT_URI  --corpus PATH    [--budget N]    [--pds-url URL] [--verifier-did DID]
+idiolect verify static-check    --lens AT_URI                   [--pds-url URL] [--verifier-did DID]
+idiolect verify coercion-law    --lens AT_URI  --vcs-url URL    --standard STD  [--version V] [--violation-threshold N] [--verifier-did DID]
+```
+
+Runs the shipped `VerificationRunner` for the named kind against
+the live PDS, prints the typed `Verification` record as JSON,
+and exits non-zero on `Falsified` / `Inconclusive` so CI surfaces
+failures.
+
+The corpus file (for `roundtrip-test` and `property-test`) may
+be a JSON array or JSON Lines. `property-test`'s generator
+cycles through the corpus by index, so `--budget` controls how
+many cases run.
+
 ## `encounter record`
 
 ```text
@@ -83,23 +148,12 @@ error: <message>
 
 Pipe stdout to `jq` for further processing.
 
-## Planned subcommands
+## Roadmap
 
-A few operations the book references on the library side are
-planned for the CLI but not shipped at v0.8.0:
-
-- `idiolect oauth login --handle <HANDLE>` — would walk the
-  OAuth dance via `atrium-oauth-client` and persist the
-  resulting session through `idiolect_oauth::OAuthTokenStore`.
-  Today the dance is driven programmatically.
-- `idiolect verify <kind> [...]` — would run any shipped
-  `VerificationRunner` from the command line and publish the
-  result. Today runners are library-only.
-- `idiolect publish <kind> --record <path>` — would load a
-  typed record from JSON and publish it under the active
-  session. Today publishing goes through
-  `idiolect_lens::RecordPublisher` from Rust.
-
-These gaps are expected pre-1.0: the library surface is the
-stable contract, and CLI subcommands accumulate as the
-hyperdeclarative spec grows.
+The shipped login path uses app passwords in legacy Bearer
+mode (`com.atproto.server.createSession` plus
+`Authorization: Bearer <token>`). The full OAuth + DPoP flow
+via `atrium-oauth` (browser handoff, PKCE, DPoP-bound tokens)
+is the next-iteration login UX; the library `OAuthSession`
+shape and `OAuthTokenStore` trait are already in place to
+receive whatever the dance returns.

--- a/docs/book/src/tutorial/03-apply-lens.md
+++ b/docs/book/src/tutorial/03-apply-lens.md
@@ -29,7 +29,7 @@ path, when working inside the workspace):
 
 ```toml
 # in Cargo.toml
-idiolect-lens   = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.9.0", features = ["pds-reqwest"] }
+idiolect-lens   = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0", features = ["pds-reqwest"] }
 panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.39.0" }
 tokio           = { version = "1", features = ["full"] }
 ```

--- a/docs/book/src/tutorial/04-verify.md
+++ b/docs/book/src/tutorial/04-verify.md
@@ -22,9 +22,9 @@ crate is library-only; runners are invoked programmatically.
 
 ```toml
 # in Cargo.toml
-idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.9.0" }
-idiolect-lens   = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.9.0", features = ["pds-reqwest"] }
-idiolect-records = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.9.0" }
+idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0" }
+idiolect-lens   = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0", features = ["pds-reqwest"] }
+idiolect-records = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0" }
 panproto-schema  = { git = "https://github.com/panproto/panproto.git", tag = "v0.47.0" }
 tokio            = { version = "1", features = ["full"] }
 ```
@@ -134,16 +134,27 @@ lens: query the verifier registry, accept the verifications they
 trust, reject the rest, and proceed only if the surviving set
 covers the properties their use case requires.
 
-## Planned functionality
+## From the CLI
 
-A future `idiolect verify <kind>` CLI subcommand would let
-operators run a runner without writing Rust. It is not shipped
-yet; runners are library-only. The four shipped runner kinds
-(`roundtrip-test`, `property-test`, `static-check`,
-`coercion-law`) cover the shape; additional kinds in the
-lexicon's `verification.kind` enum (`formal-proof`,
-`conformance-test`, `convergence-preserving`) are recognised
-slugs awaiting community-contributed runners.
+The library code above is also exposed as a CLI subcommand for
+quick operator runs. All four shipped runner kinds are wrapped:
+
+```bash
+idiolect verify roundtrip-test --lens at://.../tutorial-rename-sort-string-to-text
+idiolect verify property-test  --lens at://.../tutorial-rename-sort-string-to-text --corpus ./samples.jsonl
+idiolect verify static-check   --lens at://.../tutorial-rename-sort-string-to-text
+idiolect verify coercion-law   --lens at://... --vcs-url https://vcs.example --standard atproto-lexicon
+```
+
+The CLI prints the typed `Verification` record as JSON and
+exits non-zero on `Falsified` or `Inconclusive`, which makes it
+suitable for CI gates.
+
+Additional kinds in the lexicon's `verification.kind` enum
+(`formal-proof`, `conformance-test`, `convergence-preserving`)
+are recognised slugs awaiting community-contributed runners;
+authoring one is the
+[Author a verification runner](../guide/verify.md) loop.
 
 The next chapter publishes a `dev.idiolect.recommendation` that
 endorses a lens path under specific applicability conditions.

--- a/docs/book/src/tutorial/05-publish.md
+++ b/docs/book/src/tutorial/05-publish.md
@@ -26,7 +26,7 @@ the combinator set defined inside
 ## Author the record
 
 ```toml
-idiolect-records = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.9.0" }
+idiolect-records = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0" }
 reqwest          = { version = "0.12", features = ["json"] }
 serde            = { version = "1", features = ["derive"] }
 tokio            = { version = "1", features = ["full"] }
@@ -222,19 +222,29 @@ machine-checkable verifications attached (chapter 4 produced
 the orchestrator can fetch both, evaluate the conditions, and
 decide whether to invoke.
 
-## Planned functionality
+## From the CLI
 
-Two related CLI subcommands are planned but not shipped:
+The CLI ships both pieces of this flow:
 
-- `idiolect oauth login --handle <HANDLE>` would walk the OAuth
-  dance via `atrium-oauth-client` and persist the resulting
-  session through an `OAuthTokenStore`. Today the dance is
-  programmatic; the app-password path above is the easier
-  alternative.
-- `idiolect publish <kind> --record <path>` would load a JSON
-  file and publish it under the active session. Today publishing
-  goes through `RecordPublisher::create` (or the hand-rolled
-  client above) from Rust.
+```bash
+# 1. Authenticate (app password; legacy Bearer mode).
+idiolect oauth login --handle yourhandle.bsky.social
+# password from --app-password or env
+
+# 2. Publish a record from a JSON file.
+idiolect publish recommendation --record ./tutorial-rename-sort.json
+```
+
+`idiolect oauth login` exchanges credentials via
+`com.atproto.server.createSession` and stores the resulting
+session as a JSON file. `idiolect publish <kind>` validates the
+JSON against the typed `Record` impl, splices in `$type`, and
+POSTs `com.atproto.repo.createRecord` under the stored session.
+
+ATProto is moving off app passwords toward OAuth + DPoP; the
+next-iteration CLI wraps `atrium-oauth`'s browser-handoff dance
+and persists the resulting DPoP-bound session through the same
+`OAuthTokenStore`. The publish path is unchanged.
 
 That is the full loop. Where to go next:
 

--- a/observer-spec/methods.json
+++ b/observer-spec/methods.json
@@ -49,6 +49,12 @@
       "module": "attribution_chains",
       "struct": "AttributionChainsMethod",
       "description": "Counts of dev.idiolect.belief records by holder DID and by subject at-uri. Surfaces labeler coverage over the firehose and records that attract many third-party attributions."
+    },
+    {
+      "name": "deliberation-tally",
+      "module": "deliberation_tally",
+      "struct": "DeliberationTallyMethod",
+      "description": "Per-statement per-stance vote counts across dev.idiolect.deliberationVote records. The data shape a dev.idiolect.deliberationOutcome record carries, emitted as an observation for visibility into in-progress deliberations."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Ships the previously-planned components that the docs called out as future work, so every "Planned functionality" section is now backed by a real implementation. Sweeps those sections out of the book in the same pass.

### Shipped

- `idiolect oauth login | list | logout` — exchanges handle + app password for an access JWT via `com.atproto.server.createSession`, persists a JSON session per DID under `$IDIOLECT_SESSION_DIR` (default `~/.config/idiolect/sessions/`). **Transitional path:** app passwords in legacy Bearer mode. OAuth + DPoP browser-handoff lives in the follow-up branch `feat/oauth-dance`; the `OAuthSession` shape already carries the DPoP private-key field, so switching flows is a CLI substitution.
- `idiolect publish <kind> --record <path> [--rkey RKEY] [--did DID]` — validates the JSON against the typed `Record` impl (`decode_record(&nsid, value)`), splices in `$type`, POSTs `com.atproto.repo.createRecord` under a stored session. Short kind name (e.g. `recommendation`) maps to NSID; default rkey is TID-shaped.
- `idiolect verify <kind>` for all four shipped runners (`roundtrip-test`, `property-test`, `static-check`, `coercion-law`). Corpus accepts JSON array or JSONL; `property-test` cycles by index and takes `--budget`; `coercion-law` talks to a panproto VCS service via `dev.panproto.translate.verifyCoercionLaws`. Exits non-zero on `Falsified`/`Inconclusive` for CI gating.
- `idiolect-migrate` batch CLI binary (`cli` feature on `idiolect-migrate`): streams a JSON-records dir through `migrate_record`, exit code reflects worst-case.
- `idiolect_oauth::refresh_if_needed(&store, &refresher, did)` — loads a session, decides on refresh based on wall clock + 60-second buffer, drives the caller-supplied `Refresher::refresh`, persists, returns the live session. Generic over `S: OAuthTokenStore` + `R: Refresher` because the trait's async-fn-in-trait methods rule out trait objects.
- `deliberation-tally` registered in `observer-spec/methods.json` (the impl shipped in v0.7.0 but was missing from the spec registry).

### Versioning

Bumps workspace `0.9.0` → `0.10.0`. CHANGELOG entry under 0.10.0. Doc tag references updated.

### Follow-up

`feat/oauth-dance` — atrium-oauth + DPoP + PKCE + loopback redirect with rigorous end-to-end browser-flow testing against bsky.social. The publish path is unchanged on that branch; the only substitution is how the session lands in the store.

## Test plan

- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `mdbook build docs/book`
- [x] End-to-end smoke against live PDS (`did:plc:wdl4nnvxxdy4mc5vddxlm6f3`):
  - `idiolect verify static-check` → `result: holds`
  - `idiolect verify roundtrip-test` → `result: holds`
  - `idiolect oauth login` then `oauth list` round-trips the session
  - `idiolect publish recommendation` writes `at://.../dev.idiolect.recommendation/cli-smoke-test` with a valid CID