### PR TITLE
fix: patch RUSTSEC advisories, bump panproto to v0.56.1, fix cargo-deny CI (v0.11.1)

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -41,8 +41,10 @@ jobs:
 
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
+          # Feature selection lives in deny.toml's `[graph]`
+          # (`all-features = true`); cargo-deny 0.18 dropped the
+          # `--all-features` CLI flag.
           command: check advisories
-          arguments: --all-features
 
   npm-audit:
     name: npm audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,9 @@ jobs:
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
           command: check
-          arguments: --all-features
+          # Feature selection lives in deny.toml's `[graph]`
+          # (`all-features = true`); cargo-deny 0.18 dropped the
+          # `--all-features` CLI flag.
           log-level: warn
 
   # ---------------------------------------------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ if you depend on this project, and read this file before bumping.
 
 ### Security
 
+## [0.11.1] - 2026-07-11
+
+### Changed
+
+- Panproto pin bumped v0.52.0 → v0.56.1 across all workspace crates. No source changes were required for the surface idiolect uses (SchemaBuilder, protolens constructors, lens runtime, panproto-check, the expression engine, and the panproto-parse emit pipeline). Codegen regenerates byte-identical output on the new pin (no drift), and the full test suite passes, including the emit gate's `Verified` status for both grammars.
+
+### Fixed
+
+- cargo-deny CI jobs no longer pass `--all-features`, which cargo-deny 0.18 removed from the `check` command (the `cargo-deny-action` auto-installs the latest release, so the flag began erroring with "unexpected argument"). Feature selection now lives in `deny.toml` under `[graph]` (`all-features = true`), covering both the `cargo-deny` gate in `ci.yml` and the `cargo-deny advisories` job in `audit.yml`.
+
+### Security
+
+- Bumped `crossbeam-epoch` 0.9.18 → 0.9.20, closing RUSTSEC-2026-0204 (invalid pointer dereference in the `fmt::Pointer` impl for `Atomic`/`Shared` over a null pointer). Reached transitively through `moka`.
+- Bumped `anyhow` 1.0.102 → 1.0.103, closing RUSTSEC-2026-0190 (unsoundness in `Error::downcast_mut()` after `Error::context`).
+- Bumped `quinn-proto` 0.11.14 → 0.11.16, closing RUSTSEC-2026-0185 (remote memory exhaustion from unbounded out-of-order stream reassembly). Reached transitively through `reqwest`.
+
 ## [0.11.0] — 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ar_archive_writer"
@@ -381,6 +381,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,9 +551,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -736,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -950,11 +961,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -964,10 +973,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1296,7 +1308,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1316,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1339,7 +1351,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1353,7 +1365,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1371,7 +1383,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1397,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "idiolect-lens",
@@ -1417,7 +1429,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1435,7 +1447,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1455,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1477,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "cid",
  "language-tags",
@@ -1490,7 +1502,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1873,7 +1885,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2215,8 +2227,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "memchr",
  "panproto-gat",
@@ -2231,8 +2243,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -2241,8 +2253,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "chumsky",
  "logos",
@@ -2251,8 +2263,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -2263,8 +2275,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "cc",
  "serde",
@@ -2275,8 +2287,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -2291,8 +2303,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2308,8 +2320,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2323,8 +2335,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "memchr",
  "miette",
@@ -2344,8 +2356,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -2359,8 +2371,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.52.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.52.0#ef064ea6a4a22c6b990542f3ae15d8ba2cd57e25"
+version = "0.56.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2569,14 +2581,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2645,6 +2658,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2680,6 +2704,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2835,7 +2874,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3163,7 +3202,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3301,7 +3340,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3311,7 +3350,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"
@@ -78,17 +78,17 @@ language-tags = "0.3"
 
 # panproto: idiolect dogfoods panproto for schema codegen, breaking-change
 # detection, and lens compilation.
-panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
-panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0" }
+panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
 # panproto-parse carries the verified tree-sitter emit pipeline. Only the
 # two grammars idiolect emits are enabled; group-core would pull nine more.
-panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.52.0", default-features = false, features = ["lang-rust", "lang-typescript"] }
+panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1", default-features = false, features = ["lang-rust", "lang-typescript"] }
 
 anyhow = "1.0.100"
 

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.11.0", path = "../idiolect-records" }
-idiolect-identity = { version = "0.11.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.11.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
-idiolect-verify   = { version = "0.11.0", path = "../idiolect-verify" }
+idiolect-records  = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-identity = { version = "0.11.1", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.11.1", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-verify   = { version = "0.11.1", path = "../idiolect-verify" }
 panproto-schema   = { workspace = true }
 
 serde      = { workspace = true }

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.11.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.11.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.11.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.11.0", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.11.1", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -36,8 +36,8 @@ path = "src/bin/idiolect_migrate.rs"
 required-features = ["cli"]
 
 [dependencies]
-idiolect-records = { version = "0.11.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.11.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.11.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.11.0", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.11.0", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.11.1", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.11.0", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.11.1", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.11.0", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.11.0", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.11.1", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.11.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.11.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.11.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/deny.toml
+++ b/deny.toml
@@ -16,7 +16,10 @@ targets = [
     { triple = "aarch64-apple-darwin" },
     { triple = "x86_64-apple-darwin" },
 ]
-all-features = false
+# Check the full feature graph. cargo-deny 0.18 removed the
+# `--all-features` CLI flag, so feature selection lives here in
+# config rather than in the workflow invocation.
+all-features = true
 no-default-features = false
 
 [output]

--- a/docs/book/src/concepts/observer.md
+++ b/docs/book/src/concepts/observer.md
@@ -90,11 +90,14 @@ The shipped methods (declared in `observer-spec/methods.json`):
 | `purpose-distribution` | Encounter counts grouped by `use.purpose`. |
 | `basis-distribution` | Record counts grouped by `basis` variant. |
 | `attribution-chains` | `dev.idiolect.belief` counts by holder and subject. |
+| `deliberation-tally` | Per-statement per-stance `deliberationVote` counts. |
 
-All eight produce `dev.idiolect.observation` records. A
-`deliberation-tally` method that produces
-`dev.idiolect.deliberationOutcome` records is a plausible
-addition but is not in the shipped set at v0.8.0.
+All nine produce `dev.idiolect.observation` records. The ninth,
+`deliberation-tally`, folds `deliberationVote` records into
+per-statement per-stance counts and packs them into the
+observation's `output`; a variant that instead publishes a typed
+`dev.idiolect.deliberationOutcome` record is a small refactor on
+`DeliberationTallyMethod`.
 
 The spec is a single JSON file (`observer-spec/methods.json`),
 not a directory of files. Codegen emits the descriptor table.

--- a/docs/book/src/concepts/vocab-graph.md
+++ b/docs/book/src/concepts/vocab-graph.md
@@ -129,7 +129,7 @@ cross-vocabulary work. It exposes:
   validate every registered vocab.
 
 The exact signatures and return types are on docs.rs at
-[`idiolect_records::VocabGraph`](https://docs.rs/idiolect-records/latest/idiolect_records/struct.VocabGraph.html).
+[`idiolect_records::vocab::VocabGraph`](https://docs.rs/idiolect-records/latest/idiolect_records/vocab/struct.VocabGraph.html).
 
 ## Cross-vocab translation
 

--- a/docs/book/src/guide/index-firehose.md
+++ b/docs/book/src/guide/index-firehose.md
@@ -5,7 +5,7 @@ a firehose consumer factored into three trait surfaces:
 
 - `EventStream`: yields `RawEvent`s from a PDS firehose. Shipped
   impls: `JetstreamEventStream` (Jetstream websocket feed) and
-  `TappedFirehoseStream` (the at-proto-native firehose via
+  `TappedEventStream` (the at-proto-native firehose via
   `tapped`).
 - `RecordHandler<F: RecordFamily = IdiolectFamily>`: handles one
   decoded `IndexerEvent<F>`. The family parameter narrows the

--- a/docs/book/src/guide/observer.md
+++ b/docs/book/src/guide/observer.md
@@ -57,7 +57,7 @@ The shipped binary's exact CLI surface is documented by its
 
 ## Bundled methods
 
-The spec at `observer-spec/methods.json` declares eight bundled
+The spec at `observer-spec/methods.json` declares nine bundled
 methods. Each lives in `crates/idiolect-observer/src/methods/`.
 
 | Method | Folds |
@@ -70,6 +70,7 @@ methods. Each lives in `crates/idiolect-observer/src/methods/`.
 | `purpose-distribution` | Encounter counts grouped by `use.purpose`. |
 | `basis-distribution` | Record counts grouped by `basis` variant, bucketed by record kind. |
 | `attribution-chains` | `dev.idiolect.belief` counts by holder and subject. |
+| `deliberation-tally` | Per-statement per-stance `deliberationVote` counts (see the note below). |
 
 Methods come in two forms (declared in the spec): record-form
 methods consume `&IndexerEvent<IdiolectFamily>` directly;

--- a/docs/book/src/guide/vocabulary.md
+++ b/docs/book/src/guide/vocabulary.md
@@ -98,7 +98,7 @@ Every concept node accepts SKOS-style annotations:
   "example": "I agree with the proposal as drafted.",
   "notation": "1",
   "externalIds": [
-    { "system": "wikidata", "id": "Q4116214", "match": "exact" }
+    { "system": "wikidata", "identifier": "Q4116214", "matchType": "exact" }
   ]
 }
 ```
@@ -106,7 +106,7 @@ Every concept node accepts SKOS-style annotations:
 The full annotation set is `label`, `alternateLabels`,
 `hiddenLabels`, `description` (definition), `scopeNote`, `example`,
 `historyNote`, `editorialNote`, `changeNote`, `notation`, and
-`externalIds`. The match types on `externalIds` carry SKOS
+`externalIds`. The `matchType` values on `externalIds` carry SKOS
 semantics (`exact`, `close`, `broader`, `narrower`, `related`).
 
 A `kind: "collection"` plus `member_of` edges expresses a SKOS

--- a/docs/book/src/reference/crates/idiolect-indexer.md
+++ b/docs/book/src/reference/crates/idiolect-indexer.md
@@ -66,8 +66,8 @@ where
 | Type | Feature | Purpose |
 | --- | --- | --- |
 | `JetstreamEventStream` | `firehose-jetstream` | Subscribes to a Jetstream websocket feed. |
-| `TappedFirehoseStream` | `firehose-tapped` | Subscribes to the at-proto-native firehose via `tapped`. |
-| `ReconnectingStream<S>` | `reconnecting` | Wraps any `S: EventStream` with exponential-backoff reconnect. |
+| `TappedEventStream` | `firehose-tapped` | Subscribes to the at-proto-native firehose via `tapped`. |
+| `ReconnectingEventStream<S>` | `reconnecting` | Wraps any `S: EventStream` with exponential-backoff reconnect. |
 | `InMemoryCursorStore` | (always) | `HashMap`-backed; for tests. |
 | `FilesystemCursorStore` | `cursor-filesystem` | One JSON file per stream. |
 | `SqliteCursorStore` | `cursor-sqlite` | One row per stream. Pairs with handlers that also write SQLite. |

--- a/docs/book/src/reference/crates/idiolect-lens.md
+++ b/docs/book/src/reference/crates/idiolect-lens.md
@@ -39,7 +39,9 @@ Shipped implementations:
 ### Schema loaders
 
 `SchemaLoader` is also object-safe. Shipped implementations:
-`InMemorySchemaLoader`, `FilesystemSchemaLoader`.
+`InMemorySchemaLoader`, `FilesystemSchemaLoader`, and
+`PdsSchemaLoader` (the loader the tutorials use, pairing with
+`PdsResolver`).
 
 ### Apply functions
 

--- a/docs/book/src/reference/crates/idiolect-oauth.md
+++ b/docs/book/src/reference/crates/idiolect-oauth.md
@@ -20,8 +20,9 @@ idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8
 
 ## Public surface
 
-`OAuthTokenStore` is the trait every store implements. The
-typical surface is `get` / `put` / `delete` keyed by DID.
+`OAuthTokenStore` is the trait every store implements. Its
+methods are `save` / `load` / `delete` keyed by DID, plus a
+defaulted `list_dids`.
 `OAuthSession` carries the access token, refresh token, expiry,
 and DPoP key. The session has helpers (`is_expired`,
 `time_until_expiry`, `needs_refresh(now, threshold)`,

--- a/docs/book/src/reference/crates/idiolect-observer.md
+++ b/docs/book/src/reference/crates/idiolect-observer.md
@@ -49,7 +49,7 @@ the configured publisher.
 
 ## Shipped methods
 
-The spec at `observer-spec/methods.json` declares eight bundled
+The spec at `observer-spec/methods.json` declares nine bundled
 methods. The typed structs ship in `crates/idiolect-observer/src/methods/`:
 
 | Spec name | Module | Folds |
@@ -62,6 +62,7 @@ methods. The typed structs ship in `crates/idiolect-observer/src/methods/`:
 | `purpose-distribution` | `purpose_distribution` | Encounter counts grouped by `use.purpose`. |
 | `basis-distribution` | `basis_distribution` | Record counts grouped by `basis` variant, bucketed by record kind. |
 | `attribution-chains` | `attribution_chains` | Counts of `dev.idiolect.belief` records by holder and subject. |
+| `deliberation-tally` | `deliberation_tally` | Per-statement per-stance `deliberationVote` counts, packed into the observation's `output`. |
 
 Methods come in two forms (declared in the spec):
 

--- a/docs/book/src/reference/crates/index.md
+++ b/docs/book/src/reference/crates/index.md
@@ -17,9 +17,13 @@ versioned but bumped together at every release.
 | [idiolect-migrate](./idiolect-migrate.md) | Schema diff plus lens-based record migration. |
 | [idiolect-cli](./idiolect-cli.md) | Command-line tool wrapping the library crates. |
 
-Cargo manifests live under `crates/<name>/Cargo.toml`. Every
-shipped crate is published to crates.io under the same name and
-to docs.rs at `https://docs.rs/<name>/latest/<name_underscored>/`.
+Cargo manifests live under `crates/<name>/Cargo.toml`. Three
+crates — `idiolect-records`, `idiolect-identity`, and
+`idiolect-indexer` — are published to crates.io under the same
+name and to docs.rs at
+`https://docs.rs/<name>/latest/<name_underscored>/`. The rest are
+`publish = false` and are consumed via a git or path reference;
+each crate page states which applies.
 
 ## Policy
 

--- a/docs/book/src/reference/lexicons/vocab.md
+++ b/docs/book/src/reference/lexicons/vocab.md
@@ -84,7 +84,7 @@ metadata.
 | `changeNote` | string (≤2000 graphemes) | no | SKOS `changeNote`. |
 | `notation` | string (≤500) | no | SKOS `notation`: non-text identifier. |
 | `externalIds` | array (≤20) of `externalId` | no | Mappings to external knowledge bases. |
-| `status` | open enum | no | `proposed` / `active` / `deprecated`. |
+| `status` | open enum | no | `proposed` / `provisional` / `established` / `deprecated`. |
 | `relationMetadata` | `relationMetadata` | no | OWL Lite property characteristics. Required for `kind: relation`. |
 
 ### `vocabNode.kind`
@@ -153,9 +153,12 @@ Each `externalId` carries:
 
 | Subfield | Type | Notes |
 | --- | --- | --- |
-| `system` | string | Knowledge-base identifier (`wikidata`, `ror`, `orcid`, `lcsh`, ...). |
-| `id` | string | Identifier in that system. |
-| `match` | enum | `exact` / `close` / `broader` / `narrower` / `related`. |
+| `system` | open enum | Knowledge-base identifier (`wikidata`, `ror`, `orcid`, `lcsh`, ...). |
+| `systemVocab` | `vocabRef` | Vocab the `system` slug resolves against. |
+| `identifier` | string | Identifier in that system. |
+| `uri` | uri | Optional direct URI for the external entity. |
+| `matchType` | open enum | `exact` / `close` / `broader` / `narrower` / `related`. |
+| `matchTypeVocab` | `vocabRef` | Vocab the `matchType` slug resolves against. |
 
 External ids enable cross-system translation. A consumer holding
 two vocabs with `wikidata:Q4116214` external ids can match the

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",


### PR DESCRIPTION
## Summary

Clears the three open RUSTSEC advisories, updates the panproto pin to the latest release, fixes the failing `cargo-deny` CI jobs, and bumps the patch version to 0.11.1.

The `cargo-deny` failure was a tooling break, not a policy violation: cargo-deny 0.18 removed the `--all-features` flag from the `check` command, and `cargo-deny-action` auto-installs the latest release, so both the `cargo-deny` gate in `ci.yml` and the `cargo-deny advisories` job in `audit.yml` began erroring with "unexpected argument '--all-features'". Feature selection now lives in `deny.toml`'s `[graph]` (`all-features = true`), and the CLI flag is dropped from both workflows.

Closes #85
Closes #81
Closes #77

## Change class

- [x] bug fix
- [ ] feature (non-breaking)
- [ ] refactor (no behavior change)
- [ ] documentation only
- [x] release scaffolding / CI / build
- [ ] schema change (lexicon edit — will be classified by check-compat)

## Testing

Ran locally against the updated lockfile, all green:

- `cargo audit`: exit 0, all three RUSTSEC IDs cleared.
- `cargo deny check` (all four checks: advisories, bans, licenses, sources): ok.
- `cargo nextest run --workspace --locked`: 497 passed, 0 failed.
- `cargo test --workspace --locked --doc`: doctests pass.
- Feature matrix from `ci.yml` (`cargo test -p <crate> --features <features> --locked`) for every row: all pass.
- `cargo run -p idiolect-codegen -- generate`: no drift; generated rust and typescript sources are byte-identical on the new panproto pin.
- `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings`: clean.

Dependency deltas:

- `crossbeam-epoch` 0.9.18 -> 0.9.20 (RUSTSEC-2026-0204, reached transitively through `moka`)
- `anyhow` 1.0.102 -> 1.0.103 (RUSTSEC-2026-0190)
- `quinn-proto` 0.11.14 -> 0.11.16 (RUSTSEC-2026-0185, reached transitively through `reqwest`)
- panproto v0.52.0 -> v0.56.1 across all workspace crates

## Architecture notes

The panproto bump crosses four minor versions (0.52 to 0.56) but required no source changes to the surface idiolect uses (SchemaBuilder, protolens constructors, the lens runtime, panproto-check, the expression engine, and the panproto-parse emit pipeline). Codegen output is unchanged and the emit gate still reports `Verified` for both grammars, so the upgrade is transparent to consumers.

## Checklist

- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass locally.
- [x] `cargo test --workspace` passes locally.
- [ ] `bun run lint && bun run typecheck && bun run test` pass if the change touches TypeScript. (N/A: no TypeScript source changed; only the `@idiolect-dev/schema` package version was bumped.)
- [x] Generated sources are up-to-date (regenerated on the new panproto pin, no drift).
- [x] Relevant sections of `CHANGELOG.md` updated (entries recorded under a new `[0.11.1]` section, since this PR cuts the patch release).
