### PR TITLE
fix(lens)!: support Panproto 0.71.0 complement semantics

### DIFF
--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -23,6 +23,11 @@ on:
     branches: [main]
     paths:
       - "docs/book/**"
+      - "bun.lock"
+      - "package.json"
+      - "scripts/check_book.py"
+      - "scripts/check_book_mermaid.mjs"
+      - "scripts/check_book_rust.py"
       - ".github/workflows/book.yml"
   workflow_dispatch: {}
 
@@ -37,9 +42,16 @@ jobs:
   build-and-sync:
     name: build + sync to landing-page repo
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.2.2"
+
+      - name: install JavaScript dependencies
+        run: bun install --frozen-lockfile
 
       - name: install rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -54,6 +66,12 @@ jobs:
           cargo install --locked mdbook         --version "0.4.40"
           cargo install --locked mdbook-katex   --version "0.9.2"
           cargo install --locked mdbook-mermaid --version "0.14.0"
+
+      - name: check book source and Rust examples
+        run: |
+          python3 scripts/check_book.py
+          python3 scripts/check_book_rust.py
+          bun scripts/check_book_mermaid.mjs
 
       - name: build mdbook
         working-directory: docs/book

--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ build/
 
 # dev
 notes/
+__pycache__/
+*.py[cod]
 
 # claude code runtime state
 .claude/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ if you depend on this project, and read this file before bumping.
 
 ### Changed
 
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.12.0] - 2026-08-19
+
+### Added
+
+### Changed
+
+- **Breaking:** The view-only `apply_lens_symmetric` entry point now accepts only
+  an isomorphic incoming leg. A lossy leg requires complement state from an
+  earlier `get`; callers that retain that state must use Panproto's
+  complement-aware `SymmetricLens` API.
+
 - Panproto pins now target v0.71.0 across the workspace and the standalone
   tutorial package. The vendored `dev.panproto.*` subset is byte-identical to
   the corresponding v0.71.0 files; its provenance metadata now records the
@@ -35,9 +54,8 @@ if you depend on this project, and read this file before bumping.
 
 - Symmetric view-only lens execution now uses Panproto's
   `put_without_complement` path. Panproto 0.71.0 rejects an empty complement
-  whose shape could not have come from `get`; idiolect now reconstructs only
-  through an isomorphic incoming leg and returns a translation error for a
-  lossy leg that requires saved complement data.
+  whose shape could not have come from `get`; idiolect no longer synthesizes
+  that invalid state.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,13 @@ if you depend on this project, and read this file before bumping.
 
 ### Changed
 
-- Panproto pins now target v0.70.1 across the workspace and the standalone
+- Panproto pins now target v0.71.0 across the workspace and the standalone
   tutorial package. The vendored `dev.panproto.*` subset is byte-identical to
-  the corresponding v0.70.1 files; its provenance metadata now records the
+  the corresponding v0.71.0 files; its provenance metadata now records the
   verified upstream commit.
+- Migration planning now runs against Panproto 0.71.0's exact valued-CSP
+  morphism search. Alignment quality remains a ranking signal for one schema
+  pair, not a confidence score that can be thresholded across unrelated pairs.
 - The mdBook now provides beginner, project-integration, and advanced/formal
   reading paths while retaining separate tutorial, guide, explanation, and
   reference quadrants. Its prose, terminology links, examples, and validation
@@ -31,7 +34,7 @@ if you depend on this project, and read this file before bumping.
 ### Fixed
 
 - Symmetric view-only lens execution now uses Panproto's
-  `put_without_complement` path. Panproto 0.70.1 rejects an empty complement
+  `put_without_complement` path. Panproto 0.71.0 rejects an empty complement
   whose shape could not have come from `get`; idiolect now reconstructs only
   through an isomorphic incoming leg and returns a translation error for a
   lossy leg that requires saved complement data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,26 @@ if you depend on this project, and read this file before bumping.
 
 ### Changed
 
+- Panproto pins now target v0.70.1 across the workspace and the standalone
+  tutorial package. The vendored `dev.panproto.*` subset is byte-identical to
+  the corresponding v0.70.1 files; its provenance metadata now records the
+  verified upstream commit.
+- The mdBook now provides beginner, project-integration, and advanced/formal
+  reading paths while retaining separate tutorial, guide, explanation, and
+  reference quadrants. Its prose, terminology links, examples, and validation
+  infrastructure received a complete editorial and technical pass.
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
+
+- Symmetric view-only lens execution now uses Panproto's
+  `put_without_complement` path. Panproto 0.70.1 rejects an empty complement
+  whose shape could not have come from `get`; idiolect now reconstructs only
+  through an isomorphic incoming leg and returns a translation error for a
+  lossy leg that requires saved complement data.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,9 +31,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -46,26 +46,26 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb93bbb63b9c227414f6eb3a0adfddca591a8ce1e9b60661bb08969b87e340b"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
- "object",
+ "object 0.39.1",
 ]
 
 [[package]]
@@ -76,9 +76,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.6"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "assert-json-diff"
@@ -92,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "axum"
@@ -244,7 +244,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -281,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -304,15 +310,15 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "blake3"
-version = "1.8.4"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -333,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -345,9 +351,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "castaway"
@@ -360,9 +366,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -376,9 +382,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -393,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -421,13 +427,12 @@ dependencies = [
 
 [[package]]
 name = "cid"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbb4913a732503de004e94ce7a4e7119ffc55d1727cc9979ac3b52f511e6578c"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
 dependencies = [
  "multibase",
  "multihash",
- "no_std_io2",
  "serde",
  "serde_bytes",
  "unsigned-varint",
@@ -435,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -449,9 +454,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "compression-core",
  "flate2",
@@ -460,18 +465,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
-]
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "const-oid"
@@ -542,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -560,9 +556,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-bigint"
@@ -578,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -588,9 +584,9 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -602,15 +598,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -618,12 +614,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -661,7 +657,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -679,13 +674,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -710,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "elliptic-curve"
@@ -747,16 +742,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -785,9 +779,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "ff"
@@ -801,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -844,9 +838,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -859,9 +853,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -869,15 +863,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -886,38 +880,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -932,9 +926,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.7"
+version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
@@ -968,17 +962,15 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -1001,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1051,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
 ]
@@ -1066,12 +1058,6 @@ checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
 dependencies = [
  "hashbrown 0.14.5",
 ]
-
-[[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1090,9 +1076,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1100,9 +1086,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -1110,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1135,9 +1121,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1150,7 +1136,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "tokio",
  "want",
 ]
@@ -1168,7 +1154,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1220,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1234,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1247,30 +1233,31 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1281,15 +1268,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1299,12 +1286,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-cli"
@@ -1319,7 +1300,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tracing",
@@ -1345,8 +1326,8 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn",
- "thiserror 2.0.18",
+ "syn 2.0.119",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1357,7 +1338,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "wiremock",
@@ -1374,7 +1355,7 @@ dependencies = [
  "serde_json",
  "tapped",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite 0.24.0",
  "tracing",
@@ -1396,13 +1377,13 @@ dependencies = [
  "panproto-lens",
  "panproto-protocols",
  "panproto-schema",
- "rand 0.8.6",
+ "rand 0.8.7",
  "reqwest",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "wiremock",
 ]
@@ -1421,7 +1402,7 @@ dependencies = [
  "panproto-schema",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1440,7 +1421,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
 ]
@@ -1458,7 +1439,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tapped",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "tokio",
  "tracing",
@@ -1481,7 +1462,7 @@ dependencies = [
  "serde_json",
  "tapped",
  "tempfile",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1495,7 +1476,7 @@ dependencies = [
  "language-tags",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "url",
 ]
@@ -1510,7 +1491,7 @@ dependencies = [
  "panproto-schema",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
@@ -1522,15 +1503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "utf8_iter",
 ]
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1543,9 +1524,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1561,19 +1540,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_ci"
@@ -1598,21 +1567,20 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "json-escape-simd"
-version = "3.0.2"
+version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e770254dd7802184595b1d30da2a15cb72569e2aca2b177aef8d22eac8a693"
+checksum = "c22a2041e3874a055a4eb03ea2395aaccdefa84ce75b31d542d72a741c3c6ad3"
 
 [[package]]
 name = "langtag"
@@ -1636,16 +1604,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1666,9 +1628,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1681,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -1703,9 +1665,9 @@ dependencies = [
  "fnv",
  "proc-macro2",
  "quote",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
- "syn",
+ "regex-automata 0.4.18",
+ "regex-syntax 0.8.11",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1740,7 +1702,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1749,7 +1711,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.4.14",
+ "regex-automata 0.4.18",
 ]
 
 [[package]]
@@ -1760,9 +1722,9 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "miette"
@@ -1791,7 +1753,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1812,9 +1774,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -1823,9 +1785,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -1836,41 +1798,32 @@ dependencies = [
  "futures-util",
  "parking_lot",
  "portable-atomic",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "tagptr",
  "uuid",
 ]
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "serde",
  "unsigned-varint",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1885,14 +1838,14 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1900,15 +1853,15 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -1937,6 +1890,15 @@ name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
 ]
@@ -1975,7 +1937,7 @@ dependencies = [
  "owo-colors",
  "oxc-miette-derive",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "unicode-segmentation",
  "unicode-width 0.2.2",
 ]
@@ -1988,7 +1950,7 @@ checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1998,7 +1960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e54dd7c5eb0fa364f0b7ca09109f21cede0ae5f72001163170d954d62a0e4e86"
 dependencies = [
  "allocator-api2",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "oxc_data_structures",
  "rustc-hash",
 ]
@@ -2030,7 +1992,7 @@ dependencies = [
  "phf",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2188,7 +2150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc120670ba73a00a9d1412de98ac63b2907551707fe4063d96ee2e44cc75ab56"
 dependencies = [
  "compact_str",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "oxc_allocator",
  "oxc_estree",
 ]
@@ -2227,8 +2189,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "memchr",
  "panproto-gat",
@@ -2238,23 +2200,23 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-expr"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "rustc-hash",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "chumsky",
  "logos",
@@ -2263,20 +2225,20 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "miette",
  "panproto-expr",
  "rustc-hash",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-grammars"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "cc",
  "serde",
@@ -2287,8 +2249,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -2298,13 +2260,13 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 2.0.0-alpha.12",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-lens"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2315,13 +2277,13 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 2.0.0-alpha.12",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-mig"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2330,13 +2292,13 @@ dependencies = [
  "panproto-schema",
  "rustc-hash",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-parse"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "memchr",
  "miette",
@@ -2349,15 +2311,15 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec 2.0.0-alpha.12",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tree-sitter",
  "tree-sitter-tags",
 ]
 
 [[package]]
 name = "panproto-protocols"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -2366,20 +2328,21 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "smallvec 2.0.0-alpha.12",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-schema"
-version = "0.56.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.56.1#1504d83b8105b3c0fbbcae9781433cc8021e5440"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
  "rustc-hash",
  "serde",
  "smallvec 2.0.0-alpha.12",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2407,7 +2370,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "windows-link",
 ]
 
@@ -2457,7 +2420,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2487,21 +2450,21 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2528,7 +2491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2542,18 +2505,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.30"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3852766467df634d74f0b2d7819bf8dc483a0eb2e3b0f50f756f9cfe8b0d18d8"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -2561,9 +2524,9 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -2573,7 +2536,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -2581,12 +2544,12 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "lru-slab",
  "rand 0.10.2",
  "rand_pcg",
@@ -2595,7 +2558,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -2603,23 +2566,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -2638,9 +2601,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2649,9 +2612,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -2664,7 +2627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2732,14 +2695,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.14",
- "regex-syntax 0.8.10",
+ "regex-automata 0.4.18",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -2755,13 +2718,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
 ]
 
 [[package]]
@@ -2772,9 +2735,9 @@ checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
@@ -2811,7 +2774,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2849,20 +2812,20 @@ dependencies = [
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -2874,14 +2837,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -2893,9 +2856,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2905,9 +2868,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2915,9 +2878,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -2926,9 +2889,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "ryu"
@@ -2990,21 +2953,15 @@ dependencies = [
 
 [[package]]
 name = "self_cell"
-version = "1.2.2"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
-
-[[package]]
-name = "semver"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+checksum = "2ab42ca02749e120097e328d91d415325bdf43b1c72c4c8badf37375fe40a813"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -3022,22 +2979,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3055,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "indexmap",
  "itoa",
@@ -3101,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -3132,9 +3089,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3158,15 +3115,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -3176,9 +3133,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smallvec"
@@ -3191,18 +3148,18 @@ dependencies = [
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3223,15 +3180,15 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.23"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d74a23609d509411d10e2176dc2a4346e3b4aea2e7b1869f19fdedbc71c013"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
 dependencies = [
  "cc",
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3275,9 +3232,20 @@ checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3301,7 +3269,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3322,7 +3290,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-tungstenite 0.28.0",
  "tracing",
@@ -3337,10 +3305,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3350,7 +3318,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3375,11 +3343,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -3390,37 +3358,36 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3430,15 +3397,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3446,9 +3413,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3456,9 +3423,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3471,9 +3438,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -3487,13 +3454,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -3540,13 +3507,14 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -3609,9 +3577,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
  "bitflags",
@@ -3621,13 +3589,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -3661,7 +3629,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3694,9 +3662,9 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata 0.4.14",
+ "regex-automata 0.4.18",
  "sharded-slab",
- "smallvec 1.15.1",
+ "smallvec 1.15.2",
  "thread_local",
  "tracing",
  "tracing-core",
@@ -3705,24 +3673,24 @@ dependencies = [
 
 [[package]]
 name = "trait-variant"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70977707304198400eb4835a78f6a9f928bf41bba420deb8fdb175cd965d77a7"
+checksum = "b19a4867a870f6edc4c283f2b455804b1879c0baf0e642f26b03ed8ee262d9d3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "tree-sitter"
-version = "0.26.9"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dab76d0b724ba557954125188cf0633a1ca43199ced82d95c7b9c32cc3de1f3"
+checksum = "83c567a8e18ae93f20982c90370b16fd24023aeaf52f6052b96957ab253a0fec"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax 0.8.10",
+ "regex-syntax 0.8.11",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -3736,14 +3704,14 @@ checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
 
 [[package]]
 name = "tree-sitter-tags"
-version = "0.26.9"
+version = "0.26.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba419171ace99ea326903dffc603ce627d6936719812d50cc95ba4377abd9cd1"
+checksum = "6c3f171042e1691884237b10562b3b6be52b86fe90fe74249a46e77e59db5318"
 dependencies = [
  "memchr",
  "regex",
  "streaming-iterator",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tree-sitter",
 ]
 
@@ -3765,7 +3733,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustls",
  "rustls-pki-types",
  "sha1",
@@ -3784,19 +3752,19 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rustls",
  "rustls-pki-types",
  "sha1",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-id-start"
@@ -3818,9 +3786,9 @@ checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -3833,12 +3801,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsigned-varint"
@@ -3879,11 +3841,11 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "2cefc03fd367c0c6d4305de1b312cf00248c4114f4a0418ce6a6af769e3b0bd9"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -3929,27 +3891,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3960,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3970,9 +3923,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3980,65 +3933,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4060,14 +3979,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
 dependencies = [
- "webpki-roots 1.0.7",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4093,7 +4012,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4104,7 +4023,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4137,25 +4056,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4173,31 +4074,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4207,22 +4091,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4231,22 +4103,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4255,22 +4115,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4279,22 +4127,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
@@ -4330,109 +4166,21 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
-
-[[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4447,35 +4195,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -4488,21 +4236,21 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4511,9 +4259,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4522,17 +4270,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "9f212a141d820099d57ffafb9569be9617a6f27d3dc881fbee8fb56642f917a9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-cli"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "idiolect-lens",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cid",
  "language-tags",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2189,8 +2189,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "memchr",
  "panproto-gat",
@@ -2205,8 +2205,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -2215,8 +2215,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "chumsky",
  "logos",
@@ -2225,8 +2225,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -2237,8 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "cc",
  "serde",
@@ -2249,8 +2249,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -2265,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2282,8 +2282,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2292,13 +2292,14 @@ dependencies = [
  "panproto-schema",
  "rustc-hash",
  "serde",
+ "smallvec 2.0.0-alpha.12",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "panproto-parse"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "memchr",
  "miette",
@@ -2318,8 +2319,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -2334,9 +2335,10 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
+ "blake3",
  "panproto-expr",
  "panproto-gat",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.12.0"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,17 +78,17 @@ language-tags = "0.3"
 
 # panproto: idiolect dogfoods panproto for schema codegen, breaking-change
 # detection, and lens compilation.
-panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
-panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1" }
+panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
 # panproto-parse carries the verified tree-sitter emit pipeline. Only the
 # two grammars idiolect emits are enabled; group-core would pull nine more.
-panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.56.1", default-features = false, features = ["lang-rust", "lang-typescript"] }
+panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1", default-features = false, features = ["lang-rust", "lang-typescript"] }
 
 anyhow = "1.0.100"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,17 +78,17 @@ language-tags = "0.3"
 
 # panproto: idiolect dogfoods panproto for schema codegen, breaking-change
 # detection, and lens compilation.
-panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
 # panproto-parse carries the verified tree-sitter emit pipeline. Only the
 # two grammars idiolect emits are enabled; group-core would pull nine more.
-panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1", default-features = false, features = ["lang-rust", "lang-typescript"] }
+panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0", default-features = false, features = ["lang-rust", "lang-typescript"] }
 
 anyhow = "1.0.100"
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ conventions.
 2. A dialect is the bundle of idiolects a community treats as
 canonical.
 3. A language is the federated substrate over which idiolects and
-dialects meet, disagree, and slowly converge without a central arbiter.
+   dialects meet, disagree, and may slowly converge without a central arbiter.
 
 Architectural primitives are signed, content-addressed records on
 [ATProto](https://atproto.com). Schemas and translations between
@@ -141,7 +141,7 @@ if (isRecord(NSIDS.encounter, payload)) {
 | Crate                          | What it is                                                                |
 | ------------------------------ | ------------------------------------------------------------------------- |
 | [`idiolect-records`][recs]     | Serde record types mirroring the `dev.idiolect.*` lexicons. Generated.    |
-| [`idiolect-codegen`][cg]       | Lexicon-driven Rust + TypeScript emitter. Drives the drift gate.          |
+| [`idiolect-codegen`][cg]       | Lexicon-driven Rust + TypeScript emitter. Compares generated sources.     |
 | [`idiolect-lens`][lens]        | Resolve `PanprotoLens` records; run `apply_lens` / `apply_lens_put`.      |
 | [`idiolect-identity`][id]      | DID resolution (`did:plc` via plc.directory, `did:web` via well-known).   |
 | [`idiolect-indexer`][idx]      | Firehose consumer: `EventStream` + `RecordHandler` + `CursorStore`.       |

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
     },
     "packages/schema": {
       "name": "@idiolect-dev/schema",
-      "version": "0.11.1",
+      "version": "0.12.0",
       "dependencies": {
         "@atproto/lexicon": "0.4.8",
         "@atproto/syntax": "0.3.4",

--- a/bun.lock
+++ b/bun.lock
@@ -6,12 +6,13 @@
       "name": "idiolect-workspace",
       "devDependencies": {
         "@biomejs/biome": "2.3.0",
+        "jsdom": "26.1.0",
         "typescript": "5.7.3",
       },
     },
     "packages/schema": {
       "name": "@idiolect-dev/schema",
-      "version": "0.1.0",
+      "version": "0.11.1",
       "dependencies": {
         "@atproto/lexicon": "0.4.8",
         "@atproto/syntax": "0.3.4",
@@ -26,6 +27,8 @@
     },
   },
   "packages": {
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
+
     "@atproto/common-web": ["@atproto/common-web@0.4.21", "", { "dependencies": { "@atproto/lex-data": "^0.0.15", "@atproto/lex-json": "^0.0.16", "@atproto/syntax": "^0.5.4", "zod": "^3.23.8" } }, "sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw=="],
 
     "@atproto/lex-data": ["@atproto/lex-data@0.0.15", "", { "dependencies": { "multiformats": "^9.9.0", "tslib": "^2.8.1", "uint8arrays": "3.0.0", "unicode-segmenter": "^0.14.0" } }, "sha512-ZsbGiaM5S3CnGrcTMbDGON3bLZzCi/Mx9UvcMREKSRujnF68eHgMiXxJqvykP7+QpOX6tYCK93axZkuJVhtSEw=="],
@@ -54,6 +57,16 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.3.0", "", { "os": "win32", "cpu": "x64" }, "sha512-zOCYmCRVkWXc9v8P7OLbLlGGMxQTKMvi+5IC4v7O8DkjLCOHRzRVK/Lno2pGZNo0lzKM60pcQOhH8HVkXMQdFg=="],
 
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
     "@idiolect-dev/schema": ["@idiolect-dev/schema@workspace:packages/schema"],
 
     "@types/bun": ["@types/bun@1.2.2", "", { "dependencies": { "bun-types": "1.2.2" } }, "sha512-tr74gdku+AEDN5ergNiBnplr7hpDp3V1h7fqI2GcR/rsUaM39jpSeKH0TFibRvU0KwniRx5POgaYnaXbk0hU+w=="],
@@ -62,11 +75,61 @@
 
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
+
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "iso-datestring-validator": ["iso-datestring-validator@2.2.2", "", {}, "sha512-yLEMkBbLZTlVQqOnQ4FiMujR6T4DEcCb1xizmvXS+OxuhwcbtynoosRzdMA69zZCShCNAbi+gJ71FxZBBXx1SA=="],
 
+    "jsdom": ["jsdom@26.1.0", "", { "dependencies": { "cssstyle": "^4.2.1", "data-urls": "^5.0.0", "decimal.js": "^10.5.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.6", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.16", "parse5": "^7.2.1", "rrweb-cssom": "^0.8.0", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.1.1", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.1.1", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.0.0" }, "optionalPeers": ["canvas"] }, "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
     "multiformats": ["multiformats@9.9.0", "", {}, "sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg=="],
+
+    "nwsapi": ["nwsapi@2.2.24", "", {}, "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A=="],
+
+    "parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
@@ -77,6 +140,22 @@
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
     "unicode-segmenter": ["unicode-segmenter@0.14.5", "", {}, "sha512-jHGmj2LUuqDcX3hqY12Ql+uhUTn8huuxNZGq7GvtF6bSybzH3aFgedYu/KTzQStEgt1Ra2F3HxadNXsNjb3m3g=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
+
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
+    "ws": ["ws@8.21.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.11.1", path = "../idiolect-records" }
-idiolect-identity = { version = "0.11.1", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.11.1", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
-idiolect-verify   = { version = "0.11.1", path = "../idiolect-verify" }
+idiolect-records  = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-identity = { version = "0.12.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.12.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-verify   = { version = "0.12.0", path = "../idiolect-verify" }
 panproto-schema   = { workspace = true }
 
 serde      = { workspace = true }

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
+idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.11.1", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.12.0", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-lens/src/runtime.rs
+++ b/crates/idiolect-lens/src/runtime.rs
@@ -443,8 +443,10 @@ where
 ///
 /// Resolves both lens records, instantiates them against the shared
 /// middle schema, composes them into a [`SymmetricLens`], then runs
-/// the requested direction. The middle complement is initialized from
-/// the input record via the appropriate leg's `get`.
+/// the requested direction. This view-only API can reconstruct the
+/// middle instance only when the incoming leg is an isomorphism; a
+/// lossy leg requires a complement from an earlier `get` and is
+/// rejected.
 ///
 /// # Errors
 ///
@@ -498,9 +500,11 @@ where
             let left_view = parse_json(&left_tgt, &root, &input.record)
                 .map_err(|e| LensError::InstanceParse(e.to_string()))?;
 
-            // step one: `put` the left-view back to the middle (the span's
-            // shared source).
-            let middle_instance = panproto_lens::put(&sym.left, &left_view, &Complement::empty())
+            // Step one inverts the left leg into the span's shared
+            // middle. No prior `get` is available to supply a
+            // complement, so Panproto must verify that the leg is an
+            // isomorphism before reconstructing it.
+            let middle_instance = panproto_lens::put_without_complement(&sym.left, &left_view)
                 .map_err(|e| LensError::Translate(e.to_string()))?;
             // step two: `get` the middle forward to the right view.
             let (right_view, _) = panproto_lens::get(&sym.right, &middle_instance)
@@ -515,7 +519,7 @@ where
             let right_view = parse_json(&right_tgt, &root, &input.record)
                 .map_err(|e| LensError::InstanceParse(e.to_string()))?;
 
-            let middle_instance = panproto_lens::put(&sym.right, &right_view, &Complement::empty())
+            let middle_instance = panproto_lens::put_without_complement(&sym.right, &right_view)
                 .map_err(|e| LensError::Translate(e.to_string()))?;
             let (left_view, _) = panproto_lens::get(&sym.left, &middle_instance)
                 .map_err(|e| LensError::Translate(e.to_string()))?;

--- a/crates/idiolect-lens/tests/runtime_deep.rs
+++ b/crates/idiolect-lens/tests/runtime_deep.rs
@@ -223,10 +223,9 @@ async fn apply_lens_get_edit_errors_on_missing_lens() {
 async fn apply_lens_symmetric_returns_a_value_for_both_directions() {
     // Smoke test the symmetric-lens wiring end-to-end: legs share a
     // middle schema, both directions succeed and produce a
-    // well-formed json object. We deliberately do not compare the
-    // payload against a specific expected value — symmetric
-    // translation depends on how panproto's middle-complement is
-    // initialized, and that's panproto's contract, not idiolect's.
+    // well-formed json object. Both legs are isomorphisms, so Panproto
+    // can reconstruct the middle without a complement from an earlier
+    // `get`.
     let middle = single_field_schema("middle:root", "string");
     let protocol = test_protocol();
     let protolens = elementary::rename_sort("string", "string");

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -36,8 +36,8 @@ path = "src/bin/idiolect_migrate.rs"
 required-features = ["cli"]
 
 [dependencies]
-idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.11.1", path = "../idiolect-lens" }
+idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.12.0", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-migrate/src/plan.rs
+++ b/crates/idiolect-migrate/src/plan.rs
@@ -40,10 +40,10 @@ pub struct MigrationPlan {
     /// target. Serialize into a `PanprotoLens.blob` field when
     /// publishing.
     pub protolens_chain: ProtolensChain,
-    /// Alignment quality reported by `panproto_lens::auto_generate`
-    /// (0.0 to 1.0). Low scores — below ~0.6 — suggest the caller
-    /// should review and possibly hand-author a lens rather than
-    /// publish the auto-derived one.
+    /// Pair-relative alignment quality reported by
+    /// `panproto_lens::auto_generate` (0.0 to 1.0). Use it to compare
+    /// alternative alignments over the same source schema, not as a
+    /// confidence threshold across unrelated schema pairs.
     pub alignment_quality: f64,
 }
 

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.11.1", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.12.0", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.11.1", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.12.0", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.11.1", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.11.1", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.12.0", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.11.1", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.11.1", path = "../idiolect-lens" }
+idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.12.0", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/docs/book/README.md
+++ b/docs/book/README.md
@@ -15,6 +15,20 @@ mdbook build
 
 Output lands in `book/`.
 
+## Validate
+
+Run the structural checker before building. It parses data and shell fences,
+checks local links and anchors, resolves footnotes, enforces American spelling,
+and rejects the project's banned prose patterns. The Rust checker compiles each
+`rust` fence as an independent binary against the current checkout.
+
+```bash
+python3 ../../scripts/check_book.py
+python3 ../../scripts/check_book_rust.py
+bun ../../scripts/check_book_mermaid.mjs
+mdbook build
+```
+
 ## Serve locally
 
 ```bash
@@ -51,6 +65,10 @@ The book follows the [Diátaxis](https://diataxis.fr/) structure:
 | `src/guide/` | Task-oriented "how do I X?" guides. |
 | `src/concepts/` | Conceptual explanation of the model. |
 | `src/reference/` | Per-symbol detail (crates, lexicons, CLI, HTTP API). |
+
+The landing page and `src/paths.md` provide cross-quadrant beginner,
+project-integration, and advanced/formal routes. `src/glossary.md` supplies the
+stable terminology anchors used by each quadrant.
 
 ## Style
 

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -1,14 +1,15 @@
 # Summary
 
 [Introduction](./index.md)
+[Choose a reading path](./paths.md)
 
 # Tutorial
 
 - [Overview](./tutorial/index.md)
-- [Install and resolve a record](./tutorial/01-install.md)
-- [Validate against the lexicon](./tutorial/02-validate.md)
-- [Apply a lens](./tutorial/03-apply-lens.md)
-- [Run a verification](./tutorial/04-verify.md)
+- [Install the CLI and fetch a lens](./tutorial/01-install.md)
+- [Validate a typed record](./tutorial/02-validate.md)
+- [Apply the lens](./tutorial/03-apply-lens.md)
+- [Verify the round trip](./tutorial/04-verify.md)
 - [Publish a recommendation](./tutorial/05-publish.md)
 
 # Guides
@@ -32,7 +33,7 @@
 - [What you need first](./concepts/prerequisites.md)
 - [Idiolect, dialect, language](./concepts/idiolect-dialect-language.md)
 - [The dev.idiolect.* lexicon family](./concepts/lexicon-family.md)
-- [Records as content-addressed signed data](./concepts/atproto-records.md)
+- [Records in signed, content-addressed repositories](./concepts/atproto-records.md)
 - [Lens semantics and laws](./concepts/lens-laws.md)
 - [Open enums and vocabularies](./concepts/open-enums.md)
 - [The vocabulary knowledge graph](./concepts/vocab-graph.md)
@@ -76,3 +77,7 @@
 - [CLI](./reference/cli.md)
 - [HTTP query API](./reference/http-api.md)
 - [Stability and versioning](./reference/stability.md)
+
+# Glossary
+
+- [Terminology](./glossary.md)

--- a/docs/book/src/concepts/atproto-records.md
+++ b/docs/book/src/concepts/atproto-records.md
@@ -1,119 +1,96 @@
-# Records as content-addressed signed data
+# Records in signed, content-addressed repositories
 
-Every artifact in idiolect is an ATProto record. A record is:
+ATProto separates three coordinates that are easy to conflate: a record's
+mutable address, the CID of its current content, and the signed commit that
+authenticates a repository state. idiolect relies on all three, but its current
+runtime does not verify all three on every read.
 
-- a JSON object,
-- with a `$type` field identifying its lexicon,
-- stored at a `(did, collection, rkey)` triple,
-- content-addressed by its CID,
-- signed by the publishing repo's signing key.
+## Address, content, and proof
 
-ATProto's record model is documented in the
-[ATProto spec](https://atproto.com/specs/repository).
-This chapter covers the properties idiolect relies on.
+A [record](../glossary.md#record "A typed data object stored at a repository path")
+lives at a repository path `(collection, rkey)` owned by an account DID. An
+[AT-URI](../glossary.md#at-uri "A mutable address for an ATProto record") combines
+those coordinates:
 
-## Properties idiolect relies on
-
-### 1. Records are signed
-
-Every commit is signed by the repo's signing key. A consumer
-fetching a record can verify the signature against the repo head
-and the head against the canonical PLC directory entry. idiolect's
-trust model is rooted in those signatures: a verification record
-is only as trustworthy as its signer.
-
-The runtime does not re-validate signatures on every read. The
-shipped path is:
-
-```mermaid
-sequenceDiagram
-    Consumer->>PDS: getRecord(uri)
-    PDS-->>Consumer: { value, cid, signed_commit }
-    Consumer->>PLC: resolve did
-    PLC-->>Consumer: signing_key
-    Consumer->>Consumer: verify cid against signed_commit
-    Consumer->>Consumer: verify signed_commit against signing_key
+```text
+at://did:plc:example/dev.panproto.schema.lens/3kexample
 ```
 
-The verification step is what `idiolect-identity` plus the
-`VerifyingResolver` in `idiolect-lens` give you. Cache the
-resolved signing key, re-fetch only on cache miss, and treat a
-mismatch as a hard error.
+The AT-URI is stable across updates to that path. A
+[CID](../glossary.md#cid "A content identifier derived from encoded bytes") names
+one encoded record value. Updating the record preserves the AT-URI and changes
+the CID when its content changes.
 
-### 2. Records are content-addressed
+The repository's Merkle Search Tree maps the path to that record CID. Its root
+appears in a signed repository commit. Consequently, provenance verification is
+a chain:
 
-A record's CID is derived from its canonical bytes. Two records
-with the same content have the same CID. The CID is what the lens
-record's `object_hash` field carries, and what the
-`VerifyingResolver` checks before instantiating a lens. A
-malicious upstream cannot serve a different lens under the same
-at-uri without changing the CID, and the CID change is observable.
+```mermaid
+flowchart LR
+    URI[AT-URI path] --> MST[repository MST]
+    MST --> CID[record CID]
+    MST --> ROOT[tree root CID]
+    ROOT --> COMMIT[signed commit]
+    COMMIT --> DID[DID document key]
+```
 
-### 3. Records compose by reference
+The official [repository specification](https://atproto.com/specs/repository)
+defines this proof structure. Saying that a record is "signed" is convenient
+shorthand, but the signature is on the commit, not embedded in each record.
 
-A record can reference another record by at-uri or by `strongRef`
-(at-uri + CID). A `strongRef` is content-addressed, so the
-reference points at exactly one byte sequence. An at-uri is a
-mutable pointer.
+## Mutable and strong references
 
-idiolect uses `strongRef` for evidence (`belief.evidence`,
-`correction.encounter`, `verification.lens`) and at-uri for
-queries that should follow updates (`recommendation.lensPath`,
-`dialect.entries[].vocab`). The choice in each lexicon is
-deliberate. See the per-lexicon reference for the rationale.
+An AT-URI alone follows the current value at a path. A
+[strong reference](../glossary.md#strong-reference "An AT-URI paired with a CID to pin one record revision")
+pairs that URI with a CID. idiolect uses strong-reference-shaped definitions
+where later mutation would change the subject of a claim, including beliefs,
+deliberation statements, votes, and outcomes. Other fields intentionally use an
+AT-URI or a custom reference with an optional CID when following updates may be
+intended.
 
-### 4. Records survive PDS migration
+This choice is semantic. A vote should continue to name the statement revision
+on which it was cast; a dialect's `previousVersion` link, by contrast, names a
+record path in a version chain.
 
-ATProto's identity layer (PLC plus did:web) lets a repo move
-between PDSes without changing its `did`. A record fetched by
-at-uri after a PDS migration goes through one extra DID-resolve
-hop and arrives at the new PDS. idiolect's runtime path goes
-through `idiolect-identity` for every fetch. PDS migration is
-transparent.
+## What the current runtime verifies
 
-## Properties idiolect adds on top
+The read path has two distinct verification layers:
 
-### 5. Lexicon validation at the boundary
+1. `PdsResolver` and the PDS clients fetch record values. They do not currently
+   validate an ATProto repository proof chain or commit signature.
+2. `VerifyingResolver<R, H>` canonicalizes a resolved lens record's `blob`,
+   hashes those JSON bytes, and compares the result with that same record's
+   `objectHash`. The bundled `Sha256Hasher` accepts the `sha256:` prefix.
 
-Every shipped record kind validates against its lexicon at parse
-time. A field that violates a `format`, `maxLength`, or
-`required` constraint fails to deserialize before any business
-logic runs. The boundary is exactly where you want it.
+The second check detects disagreement between a lens blob and its declared
+application-level hash. It is not a substitute for repository signature
+verification: an untrusted response could alter both fields unless the caller
+also authenticates the record through ATProto's repository machinery.
 
-### 6. Family-typed dispatch
+The `idiolect-identity` crate resolves a DID document and its PDS service URL.
+It does not connect a fetched record CID to a signed repository commit. We call
+this missing connection the **proof-boundary gap (PBG)**. Deployments that need
+cryptographic provenance must close the PBG outside the currently shipped
+resolver stack.
 
-The codegen-emitted family modules (`idiolect_records::IdiolectFamily`)
-let consumers be generic over the family. A firehose handler that
-takes a `RecordHandler<F: RecordFamily>` filters out-of-family
-commits before decode. The crate-level reference covers
-`OrFamily<F1, F2>` for composing families.
+## What idiolect adds above storage
 
-### 7. Open enums
+ATProto supplies record addressing, repository content addressing, signed
+commits, account migration through DID service resolution, and the Lexicon
+schema language. idiolect adds typed Rust and TypeScript bindings, record-family
+dispatch, vocabulary graph queries, lens resolution, verification records, and
+community policy records.
 
-Every enum-shaped field is an open enum: known values are typed
-constants, unknown values fall through to `Other(String)`, and the
-sibling `*Vocab` field points at a `dev.idiolect.vocab` record
-where unknown values resolve. This is what lets two communities
-extend the same field without a centralized governance step. See
-[Open enums and vocabularies](./open-enums.md).
+These layers make different claims. A Lexicon describes an intended wire shape;
+a generated decoder decides whether it can construct a typed value; a lens
+relates two schema graphs; and a verification reports the result of a particular
+check. Keeping those claims separate prevents provenance, validation, and
+semantic correctness from collapsing into one ambiguous notion of "valid."
 
-### 8. Internal records do not federate
+## Records outside the public family
 
-Runtime state that should not federate (firehose cursors, OAuth
-tokens) uses the same panproto schema apparatus, but under a
-sibling `dev.idiolect.internal.*` namespace. Conformant firehose
-consumers skip the prefix. The data still travels through the
-same runtime as a public record, just out of band.
-
-## What ATProto does not give you
-
-- **A schema language.** ATProto Lexicon is a constrained type
-  language. It does not cover lens algebra, schema diffs, or
-  optic classification. Those live in panproto, which idiolect
-  embeds.
-- **A migration story.** Lexicon revision is wire-compatible by
-  policy, not by tooling. The lexicon-evolution policy fills the
-  gap. See [Lexicon evolution policy](./lexicon-evolution.md).
-- **A vocabulary registry.** Open-enum slugs need a published
-  knowledge graph to resolve, and ATProto does not ship one. The
-  `dev.idiolect.vocab` record is where the resolution lives.
+Not every runtime datum is a `dev.idiolect.*` record. Cursor stores, OAuth
+sessions, in-memory catalogs, and cached vocabulary graphs are local state.
+Some reuse generated schema machinery, but they do not become federated merely
+because they serialize. The public record family begins where a publisher
+commits a Lexicon-shaped record to an ATProto repository.

--- a/docs/book/src/concepts/deliberation.md
+++ b/docs/book/src/concepts/deliberation.md
@@ -1,111 +1,79 @@
 # Deliberation
 
-The deliberation lexicons (`deliberation`,
-`deliberationStatement`, `deliberationVote`,
-`deliberationOutcome`) describe a process as it happens. The
-`belief` and `recommendation` lexicons describe its results. The
-two are kept separate on purpose.
+The deliberation records preserve an unsettled community process. Beliefs and
+recommendations preserve attributed positions after or outside that process.
+We call this separation the **process/position split (PPS)**.
 
-## What each lexicon is for
+## Four linked records
 
 ```mermaid
 flowchart LR
-    DEL[deliberation] -->|topic, status| DST[deliberationStatement]
-    DST -->|subject of| DVO[deliberationVote]
-    DEL -->|tallied as| DOU[deliberationOutcome]
-    DOU -->|adopts| DST
+    DEL[deliberation] --> DST[deliberationStatement]
+    DST --> DVO[deliberationVote]
+    DEL --> DOU[deliberationOutcome]
+    DOU --> DST
 ```
 
-- **`dev.idiolect.deliberation`** declares a community-scoped
-  topic. Carries the owning community, an open-enum
-  `classification` (question / proposal / grievance / ...), an
-  open-enum `status` (open / closed / tabled / adopted / ...), and
-  an optional pointer to the resulting outcome.
-- **`dev.idiolect.deliberationStatement`** is one statement made
-  inside a deliberation. Carries the deliberation it belongs to,
-  the text, an open-enum `classification` (claim / proposal /
-  dissent / clarification / ...), and an `anonymous` flag with an
-  optional `authoredOn` service-DID surrogate.
-- **`dev.idiolect.deliberationVote`** is a vote on a statement.
-  Carries the statement (as a `strongRef`), an open-enum `stance`
-  (defaults to `agree` / `pass` / `disagree`), an optional
-  `weight` integer, and an optional `rationale`.
-- **`dev.idiolect.deliberationOutcome`** is an observer-published
-  tally. Carries the deliberation, per-stance counts per
-  statement, the `computedAt` timestamp, and an optional list of
-  adopted statements.
+`dev.idiolect.deliberation` names an owning community and topic. It may also
+carry a description, authentication requirement, classification, status,
+closure time, and outcome AT-URI. The known classifications are `question`,
+`proposal`, `grievance`, and `retrospective`; the known statuses include `open`,
+`closed`, `tabled`, `adopted`, and `rejected`. Both fields remain open strings.
 
-## Why this is separate from belief and recommendation
+`dev.idiolect.deliberationStatement` strongly references the deliberation and
+stores one statement. Its optional classification distinguishes claims,
+proposals, dissent, clarification, questions, and community extensions. The
+optional `anonymous` flag describes presentation policy; it does not remove the
+repository DID from ATProto provenance.
 
-A `dev.idiolect.belief` is a community's standing claim about a
-lens or schema. A `dev.idiolect.recommendation` is an opinionated
-path with conditions. Both are settled artifacts: they record what
-a community thinks, not how a community arrived there.
+`dev.idiolect.deliberationVote` strongly references one statement revision. Its
+stance defaults to the known vocabulary of `agree`, `pass`, and `disagree`, with
+an optional `stanceVocab`, integer weight, and rationale. The Lexicon constrains
+weight to the range 0 through 1000 but does not define how a community must
+interpret that number.
 
-Deliberation is the process. The four lexicons together let
-consumers see what the community considered, who voted, what the
-tally was, and which statements were adopted, before reading the
-resulting belief or recommendation. A consumer that only ever
-sees the belief is in the same position as a consumer of any
-asserted truth. A consumer that wants context can follow the
-deliberation.
+`dev.idiolect.deliberationOutcome` strongly references the deliberation and
+contains per-statement stance counts, an optional list of adopted statements, a
+computation time, and optional tool metadata. Multiple observers may publish
+different outcomes for the same deliberation.
 
-## Maps to Acorn's assembly records
+## What PPS permits
 
-Bluesky's Acorn project publishes the same shape under
-`community.blacksky.assembly.{conversation, statement, vote}`.
-The four idiolect lexicons are shaped so a future bridge to
-Acorn's records can be lossless. Stance, classification, and
-status are open-enum slugs resolved through community-published
-vocabularies. Acorn's `-1 | 0 | 1` stances become vocab nodes.
+A `dev.idiolect.belief` says that a holder stands behind a claim about a record.
+A `dev.idiolect.recommendation` advises a conditioned lens path. Neither record
+contains the statements considered, the votes cast, or the aggregation method.
 
-The bridge crate is downstream work and is not shipped. The
-lexicons are. They were designed against the assembly records so
-a future bridge can be lossless.
+The PPS permits a consumer to choose its evidential depth. A lightweight client
+may display a recommendation alone. A client auditing the decision can follow
+the community, deliberation, statement, vote, and outcome references. These
+records supply provenance coordinates; they do not guarantee a fair process or
+a correct conclusion.
 
-## How the tally is produced
+## Tallying in the current observer
 
-A `deliberationOutcome` is observer-published, not voter-published.
-The fold (in `idiolect-observer`) walks every `deliberationVote`
-that points at a statement in the deliberation, tallies stances
-per statement, and emits one outcome record per (deliberation,
-window) tuple.
+`DeliberationTallyMethod` implements one aggregation. It counts votes by strong
+statement reference and stance slug, and it sums optional weights. When
+configured with a `VocabRegistry` and canonical stance vocabulary, it translates
+stances through `equivalent_to` before counting; a slug with no translation
+remains in its original bucket.
 
-Multiple observers can publish concurrent outcomes for the same
-deliberation. Consumers can require quorum across observers
-before adopting an outcome. This is the same shape as the
-`observation` fold over encounters.
+The method's snapshot resembles
+`dev.idiolect.deliberationOutcome.statementTallies`, but the standard observer
+publisher wraps that snapshot in `dev.idiolect.observation`. The current method
+does not publish a typed `deliberationOutcome`, select adopted statements, or
+update the deliberation's `outcome` field. An application that wants those
+records must add the policy and publication step.
 
-## Open-enum extension
+## Procedure remains external
 
-The shipped vocabularies seed canonical defaults:
+The four Lexicons do not implement voter eligibility, quorum, vote delegation,
+ranked choice, quadratic weighting, or clustering. A community may describe
+some of these choices in its community conventions or a vocabulary, but the
+runtime does not infer a decision rule from the presence of `weight`.
 
-- `deliberation-classifications` (question, proposal, grievance,
-  process, position, ...).
-- `statement-classifications` (claim, proposal, dissent,
-  clarification, question, ...).
-- `deliberation-statuses` (open, closed, tabled, adopted,
-  rejected, ...).
-- `vote-stances` (agree, pass, disagree, with `polar_opposite_of`
-  edges).
-
-A community publishing its own vocab over any of these slugs can
-extend the value set without modifying the lexicons. Records
-referencing the community's vocab through the corresponding
-`*Vocab` field resolve through the extended slug set.
-
-## What this is not
-
-The deliberation lexicons do not implement Polis-style clustering,
-quadratic voting, or any specific decision procedure. They
-describe the artifacts of a deliberation. The procedure that
-produces those artifacts (and the procedure that adopts an
-outcome) is the community's choice.
-
-A community that wants quadratic voting publishes a
-`vote-weights` vocabulary and uses the optional `weight` field on
-`deliberationVote` to carry its scheme. A community that wants
-delegation publishes a `delegations` mapping (out-of-band or in
-its own lexicon) and lets observers fold votes along the
-delegation chain. The lexicons store the votes. The community's
-chosen procedure decides what they mean.
+A potential worry is that an open stance vocabulary makes two tallies
+incomparable. Vocabulary translation can reduce that problem when communities
+publish accepted equivalences. It cannot determine that an asserted
+equivalence preserves the communities' intended meanings, and untranslated
+stances remain a live possibility. The observer's method descriptor and output
+must thus accompany any comparison.

--- a/docs/book/src/concepts/idiolect-dialect-language.md
+++ b/docs/book/src/concepts/idiolect-dialect-language.md
@@ -1,81 +1,79 @@
 # Idiolect, dialect, language
 
-The project name comes from a deliberate analogy with the
-linguistic terms.
+The project borrows three linguistic terms to distinguish individual practice,
+community policy, and shared infrastructure. The analogy is organizational; it
+does not claim that schema systems have every property of natural languages.
 
-- An **idiolect** is one party's choice of schemas, lenses, and
-  conventions. It is what a single PDS (or a single application
-  developer) actually publishes.
-- A **dialect** is the bundle of idiolects a community treats as
-  canonical. It carries a list of preferred NSIDs, preferred
-  lenses, endorsed vocabularies, and deprecations.
-- A **language** is the federated substrate over which idiolects
-  and dialects meet. There is no central registry, no single
-  authority, and no global schema. The substrate is ATProto plus
-  the shipped lexicons.
+## Three levels
 
-The three layers correspond to three things in the runtime:
+An [idiolect](../glossary.md#idiolect "One publisher's actual choices of schemas, lenses, and conventions")
+is one publisher's practice: the record types it emits, the lenses it uses, and
+the conventions it follows. There is no `dev.idiolect.idiolect` record. An
+idiolect is inferred from records; a dialect's `idiolects` field lists the
+schema references that constitute its idiolect set.
 
-| Linguistic | Runtime artifact | Lexicon |
+A [dialect](../glossary.md#dialect "A community-published bundle of schema and translation policy")
+is an explicit community bundle. A `dev.idiolect.dialect` record names its
+owning community and may carry schema references in `idiolects`, along with
+`preferredLenses`, `deprecations`, and version links. The dialect is policy
+expressed as data; consuming it remains a local choice.
+
+The **language level (LL)** is the shared ATProto substrate plus the schema and
+lens records published on it. The LL has no single runtime record and no
+requirement that all participants use one schema. Local catalogs, indexers, and
+orchestrators construct views over this level.
+
+| Level | Concrete representation | Scope |
 | --- | --- | --- |
-| Idiolect | A single party's records on a PDS | (any record kind) |
-| Dialect | A bundle published by a community | `dev.idiolect.dialect` |
-| Language | The federated network of all parties | (the whole `dev.idiolect.*` family) |
+| Idiolect | A publisher's observed records and choices | One publisher or application |
+| Dialect | `dev.idiolect.dialect` | A community's stated schema and lens policy |
+| Language | ATProto repositories, event streams, Lexicons, and lenses | The federated substrate |
 
-## Why this frame
+## Plural canonicity
 
-A large protocol benefits from a model where parties can disagree
-gracefully. Two communities can run incompatible schemas and the
-substrate accommodates them. A third community can publish a lens
-between the two, and the network can route translations. The frame
-does not promise a single canonical schema. It ships the
-machinery for reasoning about plural canonicities.
+The model permits more than one community to call a different bundle canonical.
+We call this **plural canonicity (PC)**. A consumer resolves PC locally by
+choosing which community records, recommendations, vocabularies, and observers
+it trusts. The orchestrator's catalog supports that selection; it does not make
+the selection universal.
 
-The properties this gets you:
+PC has two consequences. First, a new schema can be published without a
+network-wide approval step. Second, a lens can connect established schemas
+without forcing either publisher to rename its collection. But the same freedom
+allows incompatible or malicious records, so policy cannot be derived from
+federation alone.
 
-- **No global arbiter.** There is no place to file a grievance and
-  no place to extract rent. A community can fork a dialect, ship
-  its own, and let consumers pick.
-- **Cheap experimentation.** Adding an idiolect is a record edit.
-  A community can try a new schema, see who adopts, and either
-  roll it into a dialect or abandon it.
-- **Auditable convergence.** When two communities adopt the same
-  lens, the encounter / observation / recommendation records carry
-  enough structure to make the convergence visible without a
-  central monitor.
+## Failure modes
 
-## Failure modes the frame admits
+Three failure modes recur at different levels:
 
-The frame does not promise that the network converges, that
-disagreements always resolve, or that bad actors cannot publish
-records. It admits:
+1. **Unlinked duplication.** Two NSIDs describe similar data, but no lens or
+   recommendation relates them. Consumers must either treat them separately or
+   author the missing relationship.
+2. **Vocabulary collision.** Two communities reuse a slug with different
+   intended meanings. A `*Vocab` reference can disambiguate the vocabulary, but
+   an omitted reference may leave policy to a canonical default outside the wire
+   record.
+3. **Dialect drift.** A community updates a dialect's preferred lenses or
+   deprecations. An AT-URI may then resolve to a new record CID while consumers
+   holding an older strong reference continue to see the pinned revision.
 
-- **Silent fragmentation.** Two communities ship near-identical
-  schemas under different NSIDs. Consumers see two records where
-  there should be one. The signal is the lens-recommendation
-  density between the two. If no community publishes a lens
-  between them, the fragmentation is permanent.
-- **Adversarial publishing.** A bad actor publishes a vocab that
-  shadows a canonical slug with a different meaning. The
-  containment is at the consumer's policy: prefer vocabs from
-  recognised communities, treat unknown vocabs as unknown.
-- **Dialect drift.** A community changes its dialect record
-  without coordinating with downstream consumers. Old records keep
-  validating. New lens choices route differently. The signal is
-  the deprecation list and the lexicon-evolution gate.
+A potential worry about PC is that it merely renames fragmentation. That worry
+is justified when publishers supply no lenses, evidence, or policy records. The
+model does not prevent that outcome. It makes the missing relationships visible
+and gives later publishers a common place to add them.
 
-The runtime ships primitives for each of these (recommendation,
-deliberation, lens classification) but no policy. Policy lives in
-the consumer.
+## The actual guarantees
 
-## What is not promised
+An NSID identifies an intended Lexicon shape, but repositories remain untrusted
+input; invalid records may appear on an event stream. A generated decoder can
+reject a record it cannot deserialize, though not every semantic constraint is
+enforced by deserialization alone. Likewise, a lens carries law claims, but
+those claims require checking on concrete instances or stronger external
+evidence.
 
-The frame does not promise a unified ontology, a global
-identifier scheme, or a single authoritative type for any record
-kind. It does promise that two parties using the same NSID see
-records under that NSID with the same wire shape, that lenses
-between schemas obey their stated laws, and that the lexicon
-itself does not change shape without an auditable migration.
-
-The chapters that follow cover what each of those promises means
-in practice.
+Thus, the three levels distribute responsibility rather than truth. Publishers
+choose an idiolect, communities state a dialect, and consumers decide how to
+interpret the language-level record population. The
+[`dev.idiolect.*` family](./lexicon-family.md) supplies the records used in that
+exchange.

--- a/docs/book/src/concepts/index.md
+++ b/docs/book/src/concepts/index.md
@@ -37,7 +37,7 @@ The next four chapters explain how the runtime interprets those records:
 
 [Lens semantics and laws](./lens-laws.md) is the formal center of the book. It
 introduces complements, round-trip laws, optic classification, and symmetric
-span construction against panproto 0.70.1. [Deliberation](./deliberation.md)
+span construction against panproto 0.71.0. [Deliberation](./deliberation.md)
 then separates a community's decision process from its settled beliefs and
 recommendations. [Lexicon evolution policy](./lexicon-evolution.md) closes the
 section by comparing the intended migration gate with the enforcement that the

--- a/docs/book/src/concepts/index.md
+++ b/docs/book/src/concepts/index.md
@@ -1,20 +1,44 @@
 # Concepts
 
-The Concepts section explains the model the runtime is built on.
-The chapters are self-contained but assume basic familiarity with
-ATProto records and panproto's lens vocabulary. [What you need
-first](./prerequisites.md) states the assumed background.
+The Concepts chapters explain the model behind idiolect. They begin with a
+concrete coordination failure, introduce the records that make translation
+knowledge public, and then develop the formal and governance consequences.
+Procedures stay in the [Guides](../guide/index.md); field-level contracts stay
+in [Reference](../reference/index.md).
 
-| Chapter | What it explains |
-| --- | --- |
-| [Why idiolect exists](./why-idiolect.md) | The founding problem, developed through one worked example; no formalism. |
-| [What you need first](./prerequisites.md) | The assumed background: ATProto's record model, plus one concept from panproto (the lens). |
-| [Idiolect, dialect, language](./idiolect-dialect-language.md) | The frame the project is named after; what each layer is responsible for. |
-| [The dev.idiolect.* lexicon family](./lexicon-family.md) | The shipped lexicons, what each one covers, and how they compose. |
-| [Records as content-addressed signed data](./atproto-records.md) | Why ATProto's record model is the substrate; what the runtime gets for free. |
-| [Lens semantics and laws](./lens-laws.md) | The `get` / `put` / complement model, GetPut, PutGet, optic classification. |
-| [Open enums and vocabularies](./open-enums.md) | Why every enum field is open; how `*Vocab` siblings extend slugs. |
-| [The vocabulary knowledge graph](./vocab-graph.md) | The typed multi-relation graph, OWL Lite, SKOS Core, registry queries. |
-| [Deliberation](./deliberation.md) | The deliberation lexicons, how they relate to belief / recommendation. |
-| [Observer protocol](./observer.md) | Why aggregate state lives in records, not in a central endpoint. |
-| [Lexicon evolution policy](./lexicon-evolution.md) | Every lexicon revision ships with a derived, classified, verified, published lens. |
+## A first pass
+
+Read these chapters in order if the project is new to you:
+
+1. [Why idiolect exists](./why-idiolect.md) names the private-converter problem
+   and follows one translation through the record family.
+2. [What you need first](./prerequisites.md) supplies the small amount of
+   [ATProto](https://atproto.com/guides/overview) and panproto background used
+   elsewhere.
+3. [Idiolect, dialect, language](./idiolect-dialect-language.md) separates the
+   linguistic analogy from the concrete runtime artifacts.
+4. [The `dev.idiolect.*` lexicon family](./lexicon-family.md) maps those artifacts
+   onto the sixteen record kinds shipped by the repository.
+
+## Runtime model
+
+The next four chapters explain how the runtime interprets those records:
+
+- [Records in signed, content-addressed repositories](./atproto-records.md)
+  distinguishes record identity, record content, and repository proof.
+- [Open enums and vocabularies](./open-enums.md) explains how unfamiliar slugs
+  survive decoding and acquire community-specific meanings.
+- [The vocabulary knowledge graph](./vocab-graph.md) develops the graph queries
+  behind that interpretation.
+- [Observer protocol](./observer.md) explains how event folds become
+  independently published observation records.
+
+## Formal and governance paths
+
+[Lens semantics and laws](./lens-laws.md) is the formal center of the book. It
+introduces complements, round-trip laws, optic classification, and symmetric
+span construction against panproto 0.70.1. [Deliberation](./deliberation.md)
+then separates a community's decision process from its settled beliefs and
+recommendations. [Lexicon evolution policy](./lexicon-evolution.md) closes the
+section by comparing the intended migration gate with the enforcement that the
+current checkout actually provides.

--- a/docs/book/src/concepts/lens-laws.md
+++ b/docs/book/src/concepts/lens-laws.md
@@ -1,6 +1,6 @@
 # Lens semantics and laws
 
-idiolect runs panproto 0.70.1's state-based asymmetric lenses. The basic idea is
+idiolect runs panproto 0.71.0's state-based asymmetric lenses. The basic idea is
 to retain whatever a target view cannot express, then use that retained state
 when translating backward. We call this retained state the
 [complement](../glossary.md#complement "State retained so a backward lens operation can reconstruct its source").
@@ -66,7 +66,7 @@ $$
 ## Optic classification
 
 panproto classifies a theory transform structurally with `OpticKind`. Version
-0.70.1 uses these five variants:
+0.71.0 uses these five variants:
 
 | Kind | Structural reading | Complement role |
 | --- | --- | --- |

--- a/docs/book/src/concepts/lens-laws.md
+++ b/docs/book/src/concepts/lens-laws.md
@@ -1,135 +1,147 @@
 # Lens semantics and laws
 
-A lens is a structured pair of functions between two schemas:
+idiolect runs panproto 0.70.1's state-based asymmetric lenses. The basic idea is
+to retain whatever a target view cannot express, then use that retained state
+when translating backward. We call this retained state the
+[complement](../glossary.md#complement "State retained so a backward lens operation can reconstruct its source").
+
+## State-based form
+
+For a source space $S$, view space $V$, and complement space $C$, the runtime
+shape is:
 
 $$
-\get : A \to (B, \complement) \qquad \put : (B, \complement) \to A
+\get : S \to V \times C
 $$
 
-`get` translates a source value `A` into a target view `B` plus a
-**complement** $\complement$ (the data the projection discarded).
-`put` takes a (possibly modified) `B` and the complement, and
-reconstructs an `A`.
-
-This shape is panproto's _state-based asymmetric lens_ and is
-what `idiolect-lens` runs on the wire.
-
-## The laws
-
-A well-formed lens obeys two laws.
-
-### GetPut
-
-Restoring the complement recovers the original.
-
 $$
-\put(\get(a)) = a \qquad \forall a \in A
+\put : V \times C \to S
 $$
 
-In runtime form: if you `apply_lens` a record forward and then
-`apply_lens_put` it back, you get the source bytes you started
-with.
+Given a source $s$, `get` returns a view $v$ and complement $c$. A caller may
+modify the view and then call `put` with the modified view and the original
+complement. In `idiolect-lens`, `apply_lens` and `apply_lens_put` expose these
+two directions over JSON records after parsing them into panproto instances.
 
-### PutGet
+Consider the event schemas from [Why idiolect exists](./why-idiolect.md). If the
+target has a structured `venue` but cannot represent every character of the
+source's free-text `where`, `get` may place the residual source data in $c$.
+The complement is thus record-specific state, not metadata that can be safely
+reconstructed from the lens definition alone.
 
-Lifting then projecting gives back the modified view.
+## Round-trip laws
 
-$$
-\get(\put(b, c)) = (b, c) \qquad \forall b \in B, c \in \complement
-$$
-
-In runtime form: if you write a target view through `put` and
-then read it back through `get`, the view and complement match
-what you wrote.
-
-### Iso laws
-
-When the lens is an isomorphism (no information dropped), the
-complement is empty and the laws collapse:
+A well-behaved lens satisfies two obligations. **GetPut** says that reading an
+unmodified view and writing it back recovers the source:
 
 $$
-\put(\get(a)) = a \qquad \get(\put(b)) = b
+\put(\get(s)) = s
 $$
 
-The two directions are total inverses.
+Here `put(get(s))` abbreviates destructuring the pair returned by `get` and
+passing both components to `put`.
+
+**PutGet** says that writing a view with a compatible complement and reading it
+again recovers that view:
+
+$$
+\pi_V\bigl(\get(\put(v,c))\bigr) = v
+$$
+
+The projection $\pi_V$ selects the view component. panproto's `check_laws`
+checks GetPut on one concrete source, checks PutGet on its original view, and
+also tries a mechanically modified view when one can be produced. Passing this
+check is evidence about those instances; it is not a proof over all $s$, $v$,
+and $c$.
+
+For an isomorphism the complement is empty, and the two operations are
+inverses:
+
+$$
+\put(\get(s)) = s
+\qquad
+\get(\put(v)) = v
+$$
 
 ## Optic classification
 
-panproto's classifier assigns each lens chain one of five classes,
-based on what the chain promises:
+panproto classifies a theory transform structurally with `OpticKind`. Version
+0.70.1 uses these five variants:
 
-| Class | What it promises | What it allows |
+| Kind | Structural reading | Complement role |
 | --- | --- | --- |
-| **Iso** | Bijective; both directions are total inverses. | Auto-merge under the lexicon-evolution policy. |
-| **Injection** | Source embeds in target without loss. Forward is total; backward needs no complement. | Auto-merge as forward-only. |
-| **Projection** | Target is a quotient of source; forward drops information. Backward needs the complement. | PR review under the policy. |
-| **Affine** | Partial. The forward direction may fail on some inputs. | PR review plus a community recommendation. |
-| **General** | None of the above. | Manual lens authoring, full coercion-law check, plus verification. |
+| `Iso` | Bijection | Empty |
+| `Lens` | Single-focus projection or extension | Retains dropped data or required defaults |
+| `Prism` | Variant injection | Retains a variant tag |
+| `Affine` | Composition of lens-like and prism-like behavior | Retains both forms of state |
+| `Traversal` | Multi-focus transform | Tracks focus positions |
 
-The class drives routing rather than passing judgment on quality.
-Some legitimate migrations are projections (a field genuinely went
-away). The policy makes the consequences visible.
+`classify_transform` assigns this kind from transform structure. Elementary
+transforms are intended to be lawful by construction, but classification does
+not itself run the laws. `check_optic_laws` performs the instance-level checks
+available for the classified kind.
 
-## Composition
+Composition uses the optic lattice implemented by `OpticKind::compose`: `Iso`
+is the identity, `Traversal` absorbs the other kinds, and composing `Lens` with
+`Prism` yields `Affine`. Concrete lens composition is sequential and must align
+the first lens's target schema with the second lens's source schema.
 
-Chain composition is associative:
+## Coercion classes
 
-$$
-(\ell_1 \circ \ell_2) \circ \ell_3 \;=\; \ell_1 \circ (\ell_2 \circ \ell_3)
-$$
+Primitive value conversions have a separate `CoercionClass`. The class records
+what relationship the forward and inverse functions claim:
 
-Identity is the no-op lens, a left and right identity for
-composition. panproto's protolens runtime auto-simplifies adjacent
-steps where it can (`RenameVertex(a,b) ; RenameVertex(b,c) →
-RenameVertex(a,c)`).
-
-## Symmetric lenses
-
-A symmetric lens pairs two state-based lenses that share a middle
-schema:
-
-$$
-\ell_{ab} : A \to (M, \complement_a) \qquad \ell_{bc} : B \to (M, \complement_b)
-$$
-
-Sync from $A$ to $B$ goes $A \to M \to B$, threading the
-complement through both halves. The dual sync $B \to A$ uses the
-same machinery in reverse. `apply_lens_symmetric` runs either
-direction.
-
-This is the right shape for bridging two communities' lexicons:
-each community owns its own lens to a shared middle schema, and
-the bridge stays consistent up to complement.
-
-## Coercion honesty
-
-Lens chains that cross primitive kinds (Int↔Str, Float↔Int, ...)
-declare a `CoercionClass` per kind crossing:
-
-| `CoercionClass` | When |
+| Class | Claim |
 | --- | --- |
-| `Iso` | Forward and inverse are total inverses (e.g. `Int` to its decimal string and back). |
-| `Retraction` | Forward is total; inverse recovers the forward image only. |
-| `Projection` | Forward drops information (e.g. `Float` to `Int` by truncation). |
-| `Opaque` | Documentation pair; no round-trip promise. |
+| `Iso` | Both round trips are identities. |
+| `Retraction` | The inverse recovers every value in the forward image. |
+| `Projection` | The target is deterministically derived from source data, but no inverse recovers the source from that target alone. |
+| `Opaque` | No stronger structural relationship is claimed; the complement retains the original value. |
 
-A dishonest `Iso` declaration silently corrupts the GetPut law.
-panproto ships a sample-based law checker
-(`schema theory check-coercion-laws`) that catches violations.
-The checker is wired into the lexicon-evolution gate.
+These classes compose differently from optic kinds. `Iso` is the identity,
+`Opaque` absorbs, and composing a `Retraction` with a `Projection` collapses to
+`Opaque`. panproto's sample-based coercion-law checker may falsify a declared
+class, though a finite sample cannot establish a universal law.
 
-## What you have to verify
+## Symmetric lenses as spans
 
-Stating the laws is cheap. Verifying them on a corpus is the
-work. The shipped runner kinds:
+panproto builds a symmetric lens from two asymmetric lenses with a common
+source schema $M$:
 
-- `roundtrip-test` runs GetPut on a corpus.
-- `property-test` runs an arbitrary boolean predicate.
-- `static-check` runs the panproto-level coercion-law and
-  existence checks against the chain itself.
+$$
+\ell_L : M \to L \times C_L
+$$
 
-A lens with no published verifications is a claim. A lens with
-multiple published verifications from trusted signers, run on
-recent corpora, is closer to an asserted fact. See
-[Author a verification runner](../guide/verify.md) for the
-authoring path.
+$$
+\ell_R : M \to R \times C_R
+$$
+
+To synchronize a left view into a right view, the runtime first uses the left
+leg's `put` to reconstruct a middle instance, then applies the right leg's
+`get`. This is a span through shared state, rather than a direct lens whose
+source is $L$.
+
+`idiolect-lens::apply_lens_symmetric` resolves two lens records, requires equal
+`sourceSchema` references, and constructs this span. Its JSON-level entry point
+rebuilds the middle instance with `put_without_complement`. Thus, the incoming leg
+must be isomorphic: a lossy leg that needs saved complement data is rejected.
+Callers that hold such data can instead use panproto's complement-aware
+`SymmetricLens` operations directly.
+
+## Verification records
+
+The verification Lexicon recognizes seven open-enum kinds, but the current
+`idiolect-verify` crate implements four runners:
+
+- `RoundtripTestRunner` checks forward-then-backward equality on a nonempty,
+  caller-supplied corpus.
+- `PropertyTestRunner` performs the same round trip on values from a
+  caller-supplied generator and finite budget.
+- `StaticCheckRunner` validates the source and target panproto schema graphs; it
+  does not execute the lens.
+- `CoercionLawRunner` delegates to a caller-supplied coercion-law client.
+
+A result of `holds` records that the configured run found no counterexample.
+The runner, corpus or generator, tool version, and publisher thus remain
+part of the evidence. [Author a verification runner](../guide/verify.md) covers
+the operational interface.

--- a/docs/book/src/concepts/lexicon-evolution.md
+++ b/docs/book/src/concepts/lexicon-evolution.md
@@ -16,11 +16,14 @@ in a shell script and CI workflow. It does not yet enforce the entire chain.
 returns `OnlyNonBreaking`: old records remain readable under the new schema, so
 the library does not manufacture a migration plan.
 
-If breaking changes exist, `plan_auto` asks panproto 0.70.1's `auto_generate`
-for a `ProtolensChain`. Success returns a `MigrationPlan` containing the source
-and target schema identifiers supplied by the caller, the chain, and an
-alignment-quality score. Failure returns the breaking changes that need manual
-attention.
+If breaking changes exist, `plan_auto` asks panproto 0.71.0's `auto_generate`
+for a `ProtolensChain`. Its default `Balanced` configuration uses the exact
+valued-CSP optimizer and requires a total morphism. Success returns a
+`MigrationPlan` containing the source and target schema identifiers supplied by
+the caller, the chain, and an alignment-quality score. This score ranks
+alignments for one source schema; it is not a confidence measure with a stable
+threshold across unrelated pairs. Failure returns the breaking changes that
+need manual attention.
 
 This yields three distinct outcomes:
 
@@ -50,7 +53,7 @@ those policy records is created by `plan_auto`.
 
 ## Optic kinds are not governance classes
 
-panproto 0.70.1 classifies transforms as `Iso`, `Lens`, `Prism`, `Affine`, or
+panproto 0.71.0 classifies transforms as `Iso`, `Lens`, `Prism`, `Affine`, or
 `Traversal`. Earlier versions of this chapter described a different five-way
 set, `Iso`/`Injection`/`Projection`/`Affine`/`General`, and assigned automatic
 merge policy to it. That set is not the current `OpticKind` API.
@@ -64,7 +67,7 @@ presented as classifications returned by panproto.
 
 The repository contains `scripts/lexicon-evolve.sh` and
 `.github/workflows/lexicon-evolution.yml`, but both still encode the earlier CLI
-and classification contract. With panproto 0.70.1:
+and classification contract. With panproto 0.71.0:
 
 - `schema diff` accepts positional `OLD NEW` paths rather than `--src` and
   `--tgt`, and it has no `--json` flag;
@@ -77,7 +80,7 @@ and classification contract. With panproto 0.70.1:
 The workflow makes CLI installation non-fatal and skips its pipeline when the
 installation step does not report success. It also searches for the obsolete
 classification names. Thus, the checked-in automation is a design scaffold,
-not a reliable merge gate for 0.70.1. We call this discrepancy the
+not a reliable merge gate for 0.71.0. We call this discrepancy the
 **enforcement gap (EG)**.
 
 ## A defensible gate

--- a/docs/book/src/concepts/lexicon-evolution.md
+++ b/docs/book/src/concepts/lexicon-evolution.md
@@ -1,159 +1,106 @@
 # Lexicon evolution policy
 
-Every lexicon revision in idiolect ships with an auto-derived,
-classified, verified, published lens. Hand-authored lenses are an
-escape hatch that requires governance sign-off. The same policy
-applies to vendored externals (Blacksky, layers-pub, ...).
+A Lexicon revision can preserve validation compatibility while changing what
+generated programs can safely assume. idiolect's intended response is the
+**evolution evidence chain (EEC)**: classify the schema change, derive or author
+a lens when migration is needed, verify its stated properties, publish it, and
+connect community policy to that record.
 
-The policy is the lexicon-level half of the project's stability
-story. The schema-level half is the
-[stability and versioning](../reference/stability.md) note. The
-policy below is enforced by `scripts/lexicon-evolve.sh` and the
-release CI workflow.
+The current checkout implements parts of the EEC in Rust and describes the rest
+in a shell script and CI workflow. It does not yet enforce the entire chain.
 
-## The six stages
+## Compatibility and migration are different
 
-```mermaid
-flowchart LR
-    DIFF[0. Diff] --> DERIVE[1. Auto-derivation]
-    DERIVE --> CLASSIFY[2. Classify]
-    CLASSIFY --> COERCE[3. Coercion-law check]
-    COERCE --> ROUNDTRIP[4. Roundtrip verify]
-    ROUNDTRIP --> PUBLISH[5. Publish lens]
-```
+`idiolect-migrate` begins with `panproto_check::diff` and
+`panproto_check::classify`. If a diff has no breaking changes, `plan_auto`
+returns `OnlyNonBreaking`: old records remain readable under the new schema, so
+the library does not manufacture a migration plan.
 
-Each stage maps onto a panproto primitive. Nothing is bespoke.
+If breaking changes exist, `plan_auto` asks panproto 0.70.1's `auto_generate`
+for a `ProtolensChain`. Success returns a `MigrationPlan` containing the source
+and target schema identifiers supplied by the caller, the chain, and an
+alignment-quality score. Failure returns the breaking changes that need manual
+attention.
 
-### Stage 0 — Diff
+This yields three distinct outcomes:
 
-```bash
-schema diff --src lexicons/<nsid>.<old>.json --tgt lexicons/<nsid>.<new>.json
-```
+1. no structural change;
+2. a compatible change that needs no record migration; or
+3. a breaking change that needs an auto-derived or hand-authored lens.
 
-Produces a structured change graph: vertex / edge additions,
-removals, renames, kind coercions, constraint tightenings. Cached
-under `migrations/<nsid>/<old>-<new>/diff.json`.
+Compatibility is thus a read-side property, while migration is an
+operation over existing records.
 
-### Stage 1 — Auto-derivation
+## From a plan to a published lens
 
-```bash
-schema lens generate <old>.json <new>.json --hints <hints>.json
-```
+A `MigrationPlan` is not an ATProto record. The caller must serialize its
+protolens chain into a `dev.panproto.schema.lens` `blob`, provide the schema
+record references and object hash expected by the vendored Lexicon, publish the
+record, and retain its AT-URI. `idiolect-migrate::migrate_record` can then apply
+that published lens through the normal `idiolect-lens` runtime.
 
-Produces a *protolens chain*: a sequence of dependent optics, each
-parameterized by a precondition over schemas. The elementary
-constructors are listed in
-[Lens semantics](./lens-laws.md). Hints declare anchors for
-ambiguous renames; forward-chaining propagates declared anchors
-into derived ones before the CSP solver runs.
+Verification remains a separate step. `RoundtripTestRunner` can check GetPut on
+a nonempty corpus; `PropertyTestRunner` can generate a finite set of cases;
+`StaticCheckRunner` validates the two schema graphs. These checks may falsify a
+claim. A passing finite run does not establish the corresponding universal law.
 
-### Stage 2 — Classify
+Finally, a community may add the lens to a dialect's `preferredLenses`, add a
+deprecation entry for the prior object, or publish a recommendation. None of
+those policy records is created by `plan_auto`.
 
-```bash
-schema lens inspect chain.json --protocol atproto
-```
+## Optic kinds are not governance classes
 
-Each chain receives one of five optic classes. The class drives
-the gate:
+panproto 0.70.1 classifies transforms as `Iso`, `Lens`, `Prism`, `Affine`, or
+`Traversal`. Earlier versions of this chapter described a different five-way
+set, `Iso`/`Injection`/`Projection`/`Affine`/`General`, and assigned automatic
+merge policy to it. That set is not the current `OpticKind` API.
 
-| Class | Gate behavior |
-| --- | --- |
-| **Iso** | Auto-merge. No governance review. |
-| **Injection** | Auto-merge as forward-only. |
-| **Projection** | PR review required. Complement persistence required. |
-| **Affine** | PR review plus a `dev.idiolect.recommendation` from a recognised reviewer. |
-| **General** | Manual lens authoring. Coercion-law check, verification gate, and recommendation all required. |
+A project can still define review rules over current optic kinds, complement
+requirements, compatibility reports, alignment quality, and verification
+evidence. Such rules are idiolect governance policy; they should not be
+presented as classifications returned by panproto.
 
-The class also feeds `dev.idiolect.dialect#deprecations`: any
-non-Iso lens revision implicitly deprecates the previous schema
-and must populate `deprecations` with the lens at-uri as
-`replacement`.
+## Current automation boundary
 
-### Stage 3 — Coercion-law check
+The repository contains `scripts/lexicon-evolve.sh` and
+`.github/workflows/lexicon-evolution.yml`, but both still encode the earlier CLI
+and classification contract. With panproto 0.70.1:
 
-For any `CoerceType` step crossing primitive kinds:
+- `schema diff` accepts positional `OLD NEW` paths rather than `--src` and
+  `--tgt`, and it has no `--json` flag;
+- `schema lens generate` requires `--protocol` and needs `--chain` to emit a
+  reusable chain;
+- `schema lens inspect` reports the current optic kinds; and
+- `schema lens verify` accepts a data file and optional schema, not the
+  directory/`--schema`/`--chain` combination in the script.
 
-```bash
-schema theory check-coercion-laws theory.ncl --json
-```
+The workflow makes CLI installation non-fatal and skips its pipeline when the
+installation step does not report success. It also searches for the obsolete
+classification names. Thus, the checked-in automation is a design scaffold,
+not a reliable merge gate for 0.70.1. We call this discrepancy the
+**enforcement gap (EG)**.
 
-Sample-based. Exit code is non-zero on any falsifying sample. The
-chain declares each `CoerceType` with an honest `CoercionClass`.
-Dishonest declarations corrupt the asymmetric-lens put law
-silently. This gate catches them.
+## A defensible gate
 
-### Stage 4 — Roundtrip verification
+Until the EG is closed, reviewers can apply the EEC as an explicit
+checklist:
 
-```bash
-schema lens verify <corpus>/ --protocol atproto --schema <new>.json --chain chain.json
-```
+1. compare the old and new parsed schemas with `idiolect-migrate::classify`;
+2. require a reviewed `MigrationPlan` or a hand-authored chain for each
+   breaking change;
+3. inspect the current `OpticKind` and complement requirements;
+4. run the applicable verification runners on versioned inputs;
+5. publish the lens and verification records through an authenticated writer;
+6. update dialect, deprecation, and recommendation records deliberately; and
+7. retain the artifacts that identify the two schema revisions and test corpus.
 
-Checks GetPut and PutGet over the corpus. The corpus is the live
-indexer's catalog snapshot at the time of revision: actual
-records published across the network for that NSID. CI fails on
-any record that violates either law. Verification runs on real
-data rather than synthetic test cases.
+Two points follow:
 
-### Stage 5 — Publish
+1. The EEC does not make every migration reversible.
+2. It makes the remaining assumptions and evidence inspectable.
 
-```bash
-schema lens inspect chain.json --json | idiolect-cli publish-lens \
-  --collection dev.panproto.schema.lens
-```
-
-The verified chain serializes to Nickel via `panproto-lens-dsl`
-and ships as a `dev.panproto.schema.lens` record from idiolect's
-DID. The lens at-uri is added to:
-
-- The new lexicon revision's
-  `dev.idiolect.dialect#preferredLenses`.
-- The previous lexicon's `deprecations` block as `replacement`.
-
-Codegen re-runs on revision bump. Downstream consumers pulling
-the dialect record see the lens automatically.
-
-## Vocab edits go through the same pipeline
-
-Vocab edits are *record* edits, not *schema* edits, but the same
-six stages apply via dependent optics:
-
-| Edit | Class | Action |
-| --- | --- | --- |
-| Add node, add edge | (no migration needed) | Open enums tolerate. Stage 4 corpus regression only. |
-| Remove node | Projection | Full pipeline. |
-| Rename node | Iso | `RenameEdgeName` over consumers. Auto-merge. |
-| Add `equivalent_to` between vocabs | (free) | Triggers a derived lens automatically lifted into the orchestrator's `mapEnum` cache. |
-
-## Why this is modular
-
-- **Modular.** Each elementary protolens is a stand-alone, well-typed combinator. The pipeline composes them, with no bespoke migration code per revision.
-- **Abstract.** Protolenses are quantified over schemas, not specific to a revision pair. `RenameField("oldName", "newName")` is a schema-parametric morphism; it applies to the lexicon and to every record across the network without per-record code.
-- **Composable.** Chain auto-simplification, ScopedTransform sub-chains, Nickel record merge for fragments, symmetric lenses for forward / backward pairing, lift across protocols via theory morphisms.
-- **Verifiable.** Optic classification is mechanical. Coercion-law checks are sample-based. Corpus regression uses real records. Trust rests on those mechanical checks rather than on review prose.
-- **Decentralized.** Communities author their own protolens chains for their own lexicons. The policy applies to anyone adopting idiolect's framework.
-
-## Vendored externals
-
-Vendored lexicons (Blacksky, layers-pub, ...) are consumed as
-schemas idiolect does not own. When they revise, the same six
-stages run against their old / new pair. The output is a
-*symmetric* lens (per panproto's `symmetricLens`): syncing A → B
-and B → A keeps both sides consistent up to complement. That is
-what a bridge crate needs (e.g. the planned
-`idiolect-acorn`): when the upstream changes, the bridge auto-
-updates and downstream idiolect records remain syncable.
-
-## Tooling
-
-- `scripts/lexicon-evolve.sh <nsid> <old> <new>` runs stages 0–5
-  in sequence.
-- `.github/workflows/lexicon-evolution.yml` runs stages 3–4 on
-  PR; stage 5 on tagged release.
-- A pre-commit hook runs stages 0–2 locally on every lexicon
-  edit.
-- `migrations/<nsid>/<old>-<new>/{diff.json, chain.ncl, hints.json,
-  classification.json, verification.json}` is the per-revision
-  audit trail.
-
-The policy makes lexicon evolution reviewable. The tooling makes
-the policy cheap to follow.
+This leaves two live questions: which additional evidence would justify a
+stronger reversibility claim, and which parts of the EEC should become enforced
+CI gates? The [migration guide](../guide/migrate.md) covers the current library
+path, while [Lens semantics and laws](./lens-laws.md) explains the obligations
+being tested.

--- a/docs/book/src/concepts/lexicon-family.md
+++ b/docs/book/src/concepts/lexicon-family.md
@@ -1,107 +1,120 @@
-# The dev.idiolect.* lexicon family
+# The `dev.idiolect.*` lexicon family
 
-idiolect ships sixteen record-kind lexicons plus one shared-defs
-lexicon (`dev.idiolect.defs`) under the `dev.idiolect.*`
-namespace. The record kinds are organized by what they describe.
+The repository ships sixteen record Lexicons and one shared-definitions
+Lexicon, `dev.idiolect.defs`. Together they separate event traces, aggregate
+claims, community policy, deliberation, and runtime integration.
 
 ```mermaid
 flowchart TB
-    subgraph publishing["Publishing layer"]
-        REC[recommendation]
-        BEL[belief]
-        DIA[dialect]
-        BOU[bounty]
-    end
-    subgraph events["Events"]
+    subgraph evidence["Events and evidence"]
         ENC[encounter]
         COR[correction]
-    end
-    subgraph aggregate["Aggregate"]
         OBS[observation]
         VER[verification]
         RET[retrospection]
     end
-    subgraph deliberation["Deliberation"]
+    subgraph policy["Claims and policy"]
+        BEL[belief]
+        REC[recommendation]
+        BOU[bounty]
+        DIA[dialect]
+        COM[community]
+    end
+    subgraph meaning["Meaning and integration"]
+        VOC[vocab]
+        ADA[adapter]
+    end
+    subgraph process["Deliberation process"]
         DEL[deliberation]
         DST[deliberationStatement]
         DVO[deliberationVote]
         DOU[deliberationOutcome]
     end
-    subgraph infrastructure["Infrastructure"]
-        VOC[vocab]
-        ADA[adapter]
-        COM[community]
-    end
 
-    ENC -->|folds into| OBS
-    DVO -->|tallied as| DOU
-    REC -.points at.-> VER
-    BOU -.requires.-> VER
-    BEL -.cites.-> ENC
-    BEL -.cites.-> OBS
-    COR -.corrects.-> ENC
-    DIA -.bundles.-> REC
-    DIA -.bundles.-> VOC
+    ENC --> COR
+    ENC --> OBS
+    ENC --> RET
+    VER --> REC
+    COM --> DIA
+    DEL --> DST
+    DST --> DVO
+    DEL --> DOU
 ```
 
-The arrows are by-reference relationships; the records themselves
-are independent.
+The arrows show common reference or fold relationships. They do not imply that
+publishing one record automatically creates another.
 
-## Lexicon-by-lexicon
+## Events and evidence
 
-| Lexicon | What it describes |
-| --- | --- |
-| `dev.idiolect.encounter` | One invocation of a lens. Carries the lens, the source schema, the action / material / purpose / actor (`use`), and the outcome. |
-| `dev.idiolect.observation` | Aggregate over encounters folded by an observer. Per-outcome counts plus optional weighted aggregates over a window. |
-| `dev.idiolect.correction` | A claim that a specific encounter's outcome was wrong, plus the corrected output. |
-| `dev.idiolect.belief` | A community's standing claim about a lens or schema, citing encounters / observations as evidence. |
-| `dev.idiolect.recommendation` | A community-published opinionated path: lens chain plus structured applicability conditions, preconditions, caveats, and required verifications. |
-| `dev.idiolect.bounty` | A request for someone to do verification work, with structured `wantVerification` and `constraintConformance` fields. |
-| `dev.idiolect.verification` | The outcome of a verification runner: which lens, which kind, pass/fail, structured report. |
-| `dev.idiolect.retrospection` | A post-hoc review of a sequence of encounters / observations, with a structured `finding`. |
-| `dev.idiolect.dialect` | A community-curated bundle: NSIDs, preferred lenses, endorsed vocabularies, deprecations. |
-| `dev.idiolect.community` | The community itself: members (with optional roles), record-hosting policy, optional AppView endpoint. |
-| `dev.idiolect.vocab` | A typed multi-relation knowledge graph used to resolve open-enum slugs. |
-| `dev.idiolect.adapter` | A description of an external surface (subprocess, http, wasm, ...) that consumes idiolect records, with isolation policy. |
-| `dev.idiolect.deliberation` | A community-scoped deliberation: topic, classification, status, optional outcome pointer. |
-| `dev.idiolect.deliberationStatement` | One statement made inside a deliberation. |
-| `dev.idiolect.deliberationVote` | One vote on a statement, with an open-enum stance plus optional weight + rationale. |
-| `dev.idiolect.deliberationOutcome` | An observer-published tally: per-statement per-stance counts plus optional adopted-statements. |
+- `dev.idiolect.encounter` records one lens invocation, including the lens,
+  source schema, structured use, encounter kind, and visibility.
+- `dev.idiolect.correction` attaches a path, reason, and corrected value to an
+  encounter reference.
+- `dev.idiolect.observation` carries an observer DID, method descriptor, scope,
+  version, and free-form aggregate output.
+- `dev.idiolect.verification` records a runner's `holds`, `falsified`, or
+  `inconclusive` judgment about a structured lens property.
+- `dev.idiolect.retrospection` reports a delayed finding about one encounter,
+  including detecting party, detection time, and optional confidence.
 
-The full per-lexicon reference is under
-[Lexicons](../reference/lexicons/index.md).
+These records form the **evidence chain (EC)**: an invocation may be corrected
+or reviewed later, while an observer can publish a method-specific aggregate
+over the stream it processed. The EC is plural because different parties may
+publish incompatible assessments.
 
-## Why this set
+## Claims and community policy
 
-The family was assembled to cover four concerns:
+- `dev.idiolect.belief` is a holder-attributed claim about a strongly referenced
+  record. Its subject is required; holder, basis, annotations, and visibility
+  are optional.
+- `dev.idiolect.recommendation` publishes a conditioned lens path from an
+  issuing community, with optional preconditions, verification requirements,
+  caveats, and supersession.
+- `dev.idiolect.bounty` requests a lens, adapter, or verification under stated
+  constraints and eligibility rules.
+- `dev.idiolect.dialect` bundles the schema references in a community's
+  idiolect set, along with preferred lenses, deprecations, and version links.
+- `dev.idiolect.community` describes membership, hosting policy, core schemas
+  and lenses, endorsements, and conventions.
 
-1. **What happened?** The encounter / correction / observation
-   triple. One record per invocation, with corrections and folds
-   on top.
-2. **What should happen?** The recommendation / belief / dialect /
-   verification quad. Communities express opinions, those opinions
-   cite evidence, and consumers route translations through them.
-3. **What does this mean?** The vocab + open-enum convention.
-   Slugs are open-enum strings resolved through community-published
-   knowledge graphs.
-4. **What did we decide?** The deliberation quad (deliberation,
-   statement, vote, outcome). A process-shaped counterpart to the
-   settled-belief shape.
+The distinction between belief and recommendation is intentional. Belief is an
+attributed claim about a subject; recommendation advises a translation path
+under conditions.
 
-A new record kind that fits into one of those four columns is a
-candidate for the family. A record kind that does not fit is
-likely a downstream extension. The [Bundle records into a
-dialect](../guide/dialect.md) guide covers how to ship one.
+## Meaning and integration
 
-## Composition with downstream lexicons
+`dev.idiolect.vocab` represents nodes, typed edges, relation metadata, and
+human-facing annotations. It also retains the earlier `actions`/`parents` tree
+shape, which `VocabGraph` normalizes into `subsumed_by` edges. See
+[The vocabulary knowledge graph](./vocab-graph.md).
 
-The idiolect family is meant as a base for downstream extension,
-not a fixed set. A
-downstream community publishes its own NSID family and uses
-`OrFamily<IdiolectFamily, MyFamily>` at the indexer boundary so its
-records flow alongside idiolect's. Lenses bridge the two. A
-dialect record from the downstream community lists both
-families' canonical NSIDs.
+`dev.idiolect.adapter` describes how a named framework version can be invoked
+and what isolation policy it requires. It is a declaration, not an executable
+plugin or proof that the framework is safe.
 
-The worked example of this pattern is the planned `idiolect-acorn`
-bridge. The design is in `notes/`.
+## Deliberation process
+
+The four deliberation records preserve a process before it becomes settled
+policy:
+
+1. `dev.idiolect.deliberation` names the community, topic, and optional status.
+2. `dev.idiolect.deliberationStatement` places a statement in that
+   deliberation.
+3. `dev.idiolect.deliberationVote` pins a statement revision and records a
+   stance.
+4. `dev.idiolect.deliberationOutcome` carries an observer-computed tally and
+   optional adopted statements.
+
+[Deliberation](./deliberation.md) explains why the process records remain
+separate from belief and recommendation.
+
+## Composition at the indexer boundary
+
+The Rust bindings collect these sixteen record types under `IdiolectFamily`.
+Consumers can combine it with another generated family through
+`OrFamily<F1, F2>`. That composition widens typed dispatch; it does not generate
+lenses or assert that records from the two families are semantically
+equivalent. Translation still requires an explicit lens.
+
+The [Lexicons reference](../reference/lexicons/index.md) gives the field-level
+contract for each record.

--- a/docs/book/src/concepts/observer.md
+++ b/docs/book/src/concepts/observer.md
@@ -1,137 +1,117 @@
 # Observer protocol
 
-In idiolect, aggregate state lives in records rather than in a
-served endpoint. An observer is a process that reads
-encounter-family records from the firehose, folds them along a
-key, and publishes the fold as a record.
-
-## What an observer is
+An [observer](../glossary.md#observer "A process that folds indexed records and publishes method-specific snapshots")
+turns a stream of typed records into an aggregate claim. The aggregate is a
+`dev.idiolect.observation` record when a persistent publisher is configured.
+We call this path the **published-fold path (PFP)**.
 
 ```mermaid
 flowchart LR
-    PDS[(PDS firehose)] -->|encounters| OBS[Observer process]
-    OBS -->|fold by lens, window, kind| OBSREC[observation records]
-    OBSREC --> PDS2[(observer's PDS)]
-    PDS2 --> CONSUMER[Consumer]
-    CONSUMER -->|verifies signature| OBS
+    STREAM[event stream] --> INDEX[indexer decode]
+    INDEX --> METHOD[observation method]
+    METHOD --> SNAPSHOT[snapshot output]
+    SNAPSHOT --> PUB[publisher]
+    PUB --> RECORD[observation record or local sink]
 ```
 
-- The observer subscribes to the firehose.
-- It accumulates encounters into a windowed bucket keyed by
-  `(lens, kind, window)`.
-- At window close, it computes the fold (per-outcome counts plus
-  optional weighted aggregates) and publishes one
-  `dev.idiolect.observation` record.
-- The record is signed by the observer's DID.
+## A fold is stateful
 
-The shape generalises beyond the `observation` lexicon. The same
-fold path runs over `deliberationVote` records to produce
-`deliberationOutcome` records (per-statement per-stance tallies
-plus optional adopted-statements).
-
-## Why records, not metrics
-
-A central metrics endpoint cannot:
-
-- Be verified after the fact. Once the endpoint serves a counter,
-  the counter's history is whatever the endpoint says it is.
-- Be re-folded by an independent party. A consumer that distrusts
-  the operator cannot re-derive the count from the underlying
-  data.
-- Disagree with itself across observers. A single operator
-  produces a single number.
-
-A signed record can be:
-
-- Verified against the signer's key. The same trust model as any
-  ATProto record.
-- Re-folded from the underlying encounter records. A consumer
-  reading an observation can ask the indexer for the encounters
-  in scope and recompute the fold independently.
-- Compared across observers. Two observers running the same fold
-  on overlapping data will produce records with comparable
-  counts. Consumers can require quorum before treating an
-  observation as authoritative.
-
-The cost is an extra serialization per fold and an extra commit
-per window. The shipped daemons amortize this over the window
-duration.
-
-## Fold shapes
-
-A fold is a deterministic function:
+Let $E$ be the event space, $S$ a method's private state, and $O$ its snapshot
+space. An observation method supplies a transition and a partial snapshot
+function:
 
 $$
-F : (E_1, E_2, \dots, E_n) \to R
+\operatorname{step} : S \times E \to S
 $$
 
-over the encounters $E_i$ visible in the window, producing one
-record $R$. Determinism matters because the consumer recomputing
-the fold should get the same result the observer published.
-The constraints:
+$$
+\operatorname{snapshot} : S \to O \cup \{\varnothing\}
+$$
 
-- The fold reads a stable view of the encounters in scope. The
-  observer commits the cursor only after the fold is published, so
-  a restart re-folds the window.
-- The fold does not branch on local time. The window timestamp is
-  derived from the encounters' `occurredAt`.
-- The fold does not branch on local randomness. Anything derived
-  from random sampling has to commit the seed in the record.
+Starting from $s_0$, the method processes events in stream order:
 
-The shipped methods (declared in `observer-spec/methods.json`):
+$$
+s_{i+1} = \operatorname{step}(s_i,e_i)
+$$
 
-| Method | Folds |
+If `snapshot` returns a value after $n$ events, the runtime wraps that value
+with the observer DID, method descriptor, declared scope, method version,
+visibility, and timestamp. A method may return no snapshot when it has not seen
+enough relevant data.
+
+This formulation is more accurate than treating every method as a set function.
+Some methods may be order-insensitive, but `ObservationMethod` does not require
+commutativity or idempotence. Comparability thus depends on method name,
+version, scope, input coverage, and method semantics.
+
+## Stream and flush boundaries
+
+The observer driver accepts any `idiolect_indexer::EventStream`. The reference
+daemon currently uses `TappedEventStream`, backed by a tap service; the indexer
+also has a Jetstream adapter behind its feature flag. The driver filters for
+`IdiolectFamily`, decodes creates and updates, forwards them to one configured
+method, and commits the cursor for live events after the handler succeeds.
+
+`FlushSchedule` is event-count based or manual. `EveryEvents(n)` asks the
+handler to publish after each $n$ processed events and once more when the stream
+closes normally. It does not create clock-aligned windows. A method can declare
+a window in its observation scope, but the generic driver does not enforce or
+derive that window.
+
+## What gets published
+
+Three publisher implementations exist:
+
+- `InMemoryPublisher` retains typed observations for tests and local callers.
+- `LogPublisher` emits structured tracing events without repository durability.
+- `PdsPublisher` adds `$type: "dev.idiolect.observation"` and calls the configured
+  `PdsWriter` to create a record.
+
+The reference daemon selects `CorrectionRateMethod`. It uses the in-memory
+publisher unless `IDIOLECT_PDS_URL` is set. Its PDS client is not authenticated
+by the reference binary, so a normal PDS that requires authenticated writes
+needs a wrapper or further integration before records will persist.
+
+## Bundled methods
+
+The declarative method registry and generated `default_methods()` contain nine
+record-form aggregators:
+
+| Method | Snapshot coordinate |
 | --- | --- |
-| `correction-rate` | Per-lens correction counts grouped by reason. |
-| `encounter-throughput` | Encounter traffic by kind and downstream result. |
-| `verification-coverage` | Per-lens verification counts by kind, result, and distinct verifiers. |
-| `lens-adoption` | Per-lens encounter count and distinct invokers. |
-| `action-distribution` | Encounter counts grouped by `use.action`. |
-| `purpose-distribution` | Encounter counts grouped by `use.purpose`. |
-| `basis-distribution` | Record counts grouped by `basis` variant. |
-| `attribution-chains` | `dev.idiolect.belief` counts by holder and subject. |
-| `deliberation-tally` | Per-statement per-stance `deliberationVote` counts. |
+| `correction-rate` | Correction counts by lens and reason |
+| `encounter-throughput` | Encounters by kind and downstream result |
+| `verification-coverage` | Verifications by lens, kind, result, and verifier |
+| `lens-adoption` | Encounter and invoker counts by lens |
+| `action-distribution` | Encounters by structured action |
+| `purpose-distribution` | Encounters by structured purpose |
+| `basis-distribution` | Records by basis variant and record kind |
+| `attribution-chains` | Beliefs by holder and subject |
+| `deliberation-tally` | Votes by statement and stance |
 
-All nine produce `dev.idiolect.observation` records. The ninth,
-`deliberation-tally`, folds `deliberationVote` records into
-per-statement per-stance counts and packs them into the
-observation's `output`; a variant that instead publishes a typed
-`dev.idiolect.deliberationOutcome` record is a small refactor on
-`DeliberationTallyMethod`.
+Though `default_methods()` constructs all nine, `drive_observer` is generic
+over one method and the reference daemon instantiates only `correction-rate`.
+Running multiple methods requires multiple handlers or an application-level
+composite.
 
-The spec is a single JSON file (`observer-spec/methods.json`),
-not a directory of files. Codegen emits the descriptor table.
-See [Run the observer daemon](../guide/observer.md) for the
-operator-facing path.
+## Evidence and replay
 
-## Coordination among observers
+The PFP separates aggregate state from a central query endpoint.
+Different observers can publish snapshots under their own DIDs, and consumers
+can compare them. If the record is committed to an ATProto repository, the
+repository proof can authenticate who published that snapshot.
 
-Two observers running the same fold will produce records that
-agree up to:
+But the observation record does not enumerate every input event, commit a
+digest of the input set, or prove that the method was executed as described.
+Recomputation requires access to an equivalent event history and the method's
+actual semantics. Divergent snapshots may reflect missed events, different
+cursor positions, method versions, scopes, or dishonest publication.
 
-- The window boundary they chose. Observers should align on a
-  shared cadence (e.g. UTC-aligned 1-hour windows).
-- Late-arriving encounters. Encounters posted after the window
-  closes will be folded into the next window.
-- The encounter scope the observer indexed. An observer that
-  missed a firehose segment will have a different count than one
-  that did not.
+This is the **replay boundary (RB)**. The PFP makes a claim portable; it does not
+make the claim self-proving. Consumers may impose quorum or
+observer-reputation policies above the RB, but the observation Lexicon does not
+implement either policy.
 
-Consumers that want consensus require $k$ of $n$ trusted observers
-to publish records that agree within a tolerance. This is a
-consumer policy. The runtime only provides the records.
-
-## Why folds are the right primitive
-
-A simple primitive — the observer publishes an aggregate signed
-by its DID — supports a lot of structure:
-
-- Quorum (a consumer requires multiple observers to agree).
-- Reputation (a consumer prefers observers with a track record).
-- Delegation (a consumer treats one observer's records as
-  authoritative when it does not want to fold itself).
-- Fork detection (two observers' aggregates over the same window
-  diverging is a signal that one of them is missing data).
-
-None of them require protocol changes, since they are all
-policies layered on top of records.
+The [observer guide](../guide/observer.md) covers daemon configuration. The
+[observation reference](../reference/lexicons/observation.md) gives the record
+shape.

--- a/docs/book/src/concepts/open-enums.md
+++ b/docs/book/src/concepts/open-enums.md
@@ -1,129 +1,94 @@
 # Open enums and vocabularies
 
-Closed enums are the wrong default for a federated lexicon.
-Adding a value should not require coordinating with every
-consumer. Refusing to accept a new value should not be the
-default.
+ATProto Lexicon distinguishes suggested string values from closed enumeration.
+`knownValues` lists common values but does not restrict the string; `enum`
+defines a closed set. The distinction is part of the official
+[Lexicon string specification](https://atproto.com/specs/lexicon#string).
 
-idiolect's policy is: every enum-shaped field is open, and the
-extension story is mechanical.
+idiolect builds its extension convention on `knownValues`. We call the
+combination of an open slug and an optional vocabulary reference the
+**open-enum pair (OEP)**.
 
-## The wire shape
+## Wire shape
 
-An open-enum field carries `knownValues` and a sibling `*Vocab`
-reference:
+The adapter Lexicon contains an OEP for its invocation protocol:
 
 ```json
-"kind": {
-  "type": "string",
-  "knownValues": ["subprocess", "http", "wasm"],
-  "description": "Slug; resolves as a node in the vocab referenced by `kindVocab`."
-},
-"kindVocab": {
-  "type": "ref",
-  "ref": "dev.idiolect.defs#vocabRef",
-  "description": "Vocabulary record whose nodes constitute the open extension."
+{
+  "kind": {
+    "type": "string",
+    "knownValues": ["subprocess", "http", "wasm"]
+  },
+  "kindVocab": {
+    "type": "ref",
+    "ref": "dev.idiolect.defs#vocabRef"
+  }
 }
 ```
 
-`kindVocab` is optional. When omitted, the canonical
-idiolect-published vocab for that field is the implicit default.
-A community-published vocab listed here extends the slugs the
-field accepts.
+The record's `kind` value may be `subprocess` or a value that did not exist when
+the consumer generated its bindings. `kindVocab`, when present, identifies a
+[vocabulary](../glossary.md#vocabulary "A published graph that assigns relations and annotations to open slugs")
+in which the slug can be interpreted.
 
-## The codegen shape
+Many idiolect Lexicons describe an omitted `*Vocab` field as selecting a
+canonical project vocabulary. That default is a convention in the schema
+description, not a URI inserted by deserialization. A consumer that needs graph
+semantics must choose or configure the default record itself.
 
-`idiolect-codegen` reads `knownValues` and emits:
+## Generated bindings
 
-```rust
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Kind {
-    Subprocess,
-    Http,
-    Wasm,
-    Other(String),
-}
-```
+The Rust generator turns the example into
+`AdapterInvocationProtocolKind::{Subprocess, Http, Wasm, Other(String)}`.
+Serialization preserves the wire slug, including the string inside `Other`.
+The TypeScript generator emits the literal union
+`"subprocess" | "http" | "wasm" | string & {}` so editors retain completion for
+known values without rejecting extensions.
 
-Plus hand-written `Serialize` / `Deserialize` impls that round-trip
-unknown slugs through `Other(String)`. The TypeScript half emits
-`'a' | 'b' | (string & {})` for the same purpose.
+Rust open-enum types also expose three graph-facing operations:
 
-Three helper methods sit on every emitted open-enum type:
+- `is_subsumed_by` tests the `subsumed_by` relation in one `VocabGraph`.
+- `satisfies` tests reachability under a caller-selected relation.
+- `translate_to` asks a `VocabRegistry` for an `equivalent_to` translation
+  between two registered vocabulary URIs.
 
-```rust
-impl Kind {
-    pub fn is_subsumed_by(
-        &self,
-        graph: &VocabGraph,
-        ancestor: &str,
-    ) -> bool { /* ... */ }
+None of these methods fetches a vocabulary record. Loading, validating, and
+caching those records remains the caller's responsibility.
 
-    pub fn satisfies(
-        &self,
-        graph: &VocabGraph,
-        relation: &str,
-        target: &str,
-    ) -> bool { /* ... */ }
+## Preservation before interpretation
 
-    pub fn translate_to<T: From<String>>(
-        &self,
-        src_vocab_uri: &str,
-        tgt_vocab_uri: &str,
-        registry: &VocabRegistry,
-    ) -> Option<T> { /* ... */ }
-}
-```
+The OEP separates two requirements. **Preservation** means that an old consumer
+can decode and reserialize an unfamiliar slug without replacing it. Generated
+`Other(String)` variants provide that behavior. **Interpretation** means that a
+consumer knows how the slug relates to a requirement such as `subprocess`.
+Interpretation requires a loaded graph and a relation query.
 
-These are what consumers call instead of comparing strings. A
-consumer asking "is this `kind` a subprocess?" calls
-`k.is_subsumed_by(&vocab, "subprocess")` and gets `true` for any
-slug the vocab declares as `subsumed_by` subprocess (`docker-run`,
-`fly-machines-launch`, etc.) without changing the consumer's code.
+This separation avoids a common failure mode in federated systems: treating an
+unknown value as invalid merely because local code has not seen it. It does not
+require a consumer to accept the value for every purpose. A policy may preserve
+`fly-machine` on the wire and still decline to execute it because the relevant
+vocabulary is missing or untrusted.
 
-## Why this shape
+## Closed fields
 
-Closed enums force a coordination problem: adding a value requires
-every consumer to upgrade their code before any producer publishes
-the new value. Open enums turn it into a vocabulary problem: the
-producer publishes the vocab, the consumer queries the vocab at
-runtime, and unknown slugs degrade gracefully to `Other(String)`
-when the consumer has not loaded the vocab.
+The shipped Lexicons still use `enum` for meta-policy fields whose extension
+would alter a parser or runtime contract. `vocab.world` and the per-relation
+`world` override, for instance, are closed over `open`, `closed-with-default`,
+and `hierarchy-closed`. Unions may also be explicitly closed under the Lexicon
+rules.
 
-The cost is one extra indirection per slug interpretation. The
-shipped `VocabRegistry` caches vocabs by at-uri, so the cost is
-amortized across the process lifetime.
+Changing a field from `enum` to `knownValues` expands the accepted wire values,
+but it can also change generated source types. Existing record values remain in
+the larger set; downstream code still needs regeneration and review.
 
-## What stays closed
+## Identifier collisions
 
-A few fields are intentionally closed. They are meta-policy fields
-where extending the value space would change the runtime's
-contract, not the data:
+Distinct slugs can normalize to the same Rust variant name. The generator keeps
+the first name and adds a numeric suffix to later collisions, deterministically
+within the generated enum. It also avoids using `Other` as the fallback name
+when `Other` is itself a declared slug, selecting another fallback variant
+instead. These rules preserve every wire value, though authors should still
+prefer slugs whose generated names remain readable.
 
-- `vocab.world` (`open` / `closed-with-default` / `hierarchy-closed`)
-  controls the runtime's open-enum policy itself.
-- `lensClass` (`isomorphism` / `injection` / `projection` /
-  `affine` / `general`) is a panproto contract. Extending it
-  changes what the runtime promises.
-- `recordHosting` (`member-hosted` / `community-hosted` / `hybrid`)
-  controls a federation policy.
-
-A new value here is a runtime change, not a record change.
-
-## Migration
-
-Converting a closed enum to an open enum is wire-compatible:
-existing records continue to validate, and the codegen-emitted
-helpers degrade to "if `Other`, ignore" in consumers that have
-not regenerated. Going the other way is breaking, and the shipped
-lexicons do not do that.
-
-## Codegen identifier collisions
-
-When two distinct slugs would pascal-case to the same Rust
-identifier (`foo-bar` and `foo_bar`), the second occurrence gets
-a numeric suffix (`FooBar2`). The collision is resolved
-deterministically per lexicon, so two regenerations of the same
-lexicon produce the same identifier names. The collision report
-is printed at codegen time so authors can rename a slug when the
-generated name is awkward.
+[The vocabulary knowledge graph](./vocab-graph.md) develops the graph semantics
+that turn preserved strings into queryable relations.

--- a/docs/book/src/concepts/prerequisites.md
+++ b/docs/book/src/concepts/prerequisites.md
@@ -1,78 +1,67 @@
 # What you need first
 
-idiolect's two dependencies are prerequisites of different kinds.
+idiolect depends on ATProto for publication and on panproto for schema
+translation. Readers need three ATProto objects and one panproto object. The
+definitions below are sufficient for the rest of the Concepts chapters.
 
-The ATProto dependency is deep. idiolect is founded on ATProto's
-ideas (self-owned repositories, signed content-addressed records,
-schemas anyone can publish, federation without a central arbiter),
-and its design decisions assume that model; without it, they will
-read as arbitrary. If
-you have not worked with ATProto, plan to spend time with the
-[ATProto documentation](https://atproto.com/guides/overview); this
-book does not substitute for it. This page states the three
-ATProto ideas the book leans on hardest. If they read as familiar,
-continue; if not, follow the links first.
+## ATProto repositories and records
 
-The panproto dependency, by contrast, is shallow for readers. The runtime uses
-panproto heavily, but this book requires exactly one concept from
-it (the lens), stated in the last section below. You do not need
-to read the panproto book, and no category theory appears anywhere
-in this book.
+An ATProto account controls a public
+[repository](../glossary.md#repository "An account-scoped, verifiable collection of ATProto records").
+A [record](../glossary.md#record "A typed data object stored at a repository path")
+occupies a path of the form `collection/rkey`; an
+[AT-URI](../glossary.md#at-uri "A mutable address for an ATProto record") adds the
+account DID:
 
-## From ATProto: record
+```text
+at://did:plc:example/dev.idiolect.verification/3kexample
+```
 
-A *record* is a piece of JSON that lives in a repository controlled
-by one account (identified by a DID). Records are signed and
-content-addressed, so anyone can verify who published a record and
-that it has not been altered. Every record has an address of the
-form `at://did/collection/key`. Everything idiolect publishes
-(lenses, verifications, recommendations, dialects) is a record.
-The runtime consequences of this choice are the subject of
-[Records as content-addressed signed data](./atproto-records.md).
+The repository is a content-addressed Merkle Search Tree whose leaves point to
+record CIDs. The repository *commit* is signed; an individual record is not a
+stand-alone signed document. A proof chain can connect a record CID to that
+signed commit. This distinction, specified in the official
+[ATProto repository format](https://atproto.com/specs/repository), must be
+accounted for when evaluating provenance claims.
 
-## From ATProto: lexicon
+## Lexicons and NSIDs
 
-A *lexicon* is ATProto's schema language: a JSON document that
-declares the shape of a record type and names it with an *NSID*, a
-reverse-domain identifier such as `app.bsky.feed.post` or
-`dev.idiolect.recommendation`. Anyone who controls a domain can
-publish lexicons under it. This is the source of the problem
-idiolect addresses: independent parties can, and do, publish
-different lexicons for the same kind of thing. The lexicons this
-project ships are catalogued in [the lexicon
-family](./lexicon-family.md).
+A [Lexicon](../glossary.md#lexicon "ATProto's schema language for records and XRPC")
+is an ATProto schema document. Its
+[NSID](../glossary.md#nsid "A reverse-domain identifier for an ATProto schema or method")
+names a record collection or XRPC method; `dev.idiolect.recommendation` is one
+such collection. The [Lexicon specification](https://atproto.com/specs/lexicon)
+defines the record, object, reference, union, and scalar forms used throughout
+this repository.
 
-## From ATProto: PDS and firehose
+Independent publishers may define different NSIDs for similar data. Lexicon
+validation can determine whether a value has the declared shape, but it cannot
+determine that two independently named shapes describe the same thing. idiolect
+addresses that second problem.
 
-A *PDS* (personal data server) hosts repositories. The *firehose*
-is the network-wide event stream of record creations, updates, and
-deletions that consumers subscribe to. The load-bearing facts for
-this book: records live on many independent servers, and there is
-a stream you can watch to see all of them. idiolect's indexer,
-orchestrator, and observer are consumers of that stream; the
-[tutorial](../tutorial/01-install.md) has you fetch records
-without running any of them.
+## PDSes and event streams
 
-## From panproto: lens
+A [personal data server (PDS)](../glossary.md#pds "The service that hosts an account's authoritative ATProto repository")
+hosts an account's authoritative repository. Network consumers usually learn about
+record changes through a synchronization stream or a derived transport such as
+Jetstream or tap. The book uses *event stream* for the abstraction and
+*firehose* when referring to the network-wide ATProto stream specifically.
 
-A *lens* is a two-way converter between two schemas. The forward
-direction (`get`) translates a record from the source shape to the
-target shape and sets aside whatever the target shape cannot
-express; the set-aside part is called the *complement*. The
-backward direction (`put`) uses the complement to reconstruct the
-original exactly. A lens is not trusted on its author's word: it
-obeys stated round-trip laws, and the laws can be checked
-mechanically against real records. Nothing more from panproto is
-assumed in this book. The laws, the classification of lenses by
-what they promise, and the symmetric variant used for bridging two
-communities are in [Lens semantics and laws](./lens-laws.md), and
-that chapter restates each of them before use.
+The current indexer accepts a generic `EventStream`. Concrete adapters cover
+tap and Jetstream; thus a conceptual statement about an event fold does not
+imply that every process connects directly to a PDS.
 
-## Where to deepen
+## Panproto lenses
 
-The [ATProto documentation](https://atproto.com/guides/overview)
-is the real prerequisite if the three paragraphs above were not
-already familiar. The [panproto book](https://panproto.dev/book/)
-is optional depth on the schema and lens machinery. [Why idiolect
-exists](./why-idiolect.md) explains why the project builds on
-both.
+A [lens](../glossary.md#lens "A bidirectional schema translation with explicit round-trip obligations")
+relates a source schema to a target schema. Its forward operation, `get`,
+produces a target view and a
+[complement](../glossary.md#complement "State retained so a backward lens operation can reconstruct its source")
+containing source information that the view did not retain. Its backward
+operation, `put`, combines a target view with that complement to reconstruct a
+source value.
+
+idiolect uses panproto 0.70.1 to instantiate and run these lenses. No category
+theory is assumed: [Lens semantics and laws](./lens-laws.md) introduces the
+notation before using it, while the [panproto book](https://panproto.dev/book/)
+provides optional depth.

--- a/docs/book/src/concepts/prerequisites.md
+++ b/docs/book/src/concepts/prerequisites.md
@@ -61,7 +61,7 @@ containing source information that the view did not retain. Its backward
 operation, `put`, combines a target view with that complement to reconstruct a
 source value.
 
-idiolect uses panproto 0.70.1 to instantiate and run these lenses. No category
+idiolect uses panproto 0.71.0 to instantiate and run these lenses. No category
 theory is assumed: [Lens semantics and laws](./lens-laws.md) introduces the
 notation before using it, while the [panproto book](https://panproto.dev/book/)
 provides optional depth.

--- a/docs/book/src/concepts/vocab-graph.md
+++ b/docs/book/src/concepts/vocab-graph.md
@@ -1,170 +1,123 @@
 # The vocabulary knowledge graph
 
-`dev.idiolect.vocab` is a typed multi-relation knowledge graph.
-A vocabulary record carries:
+`dev.idiolect.vocab` gives open-enum slugs a graph-shaped interpretation. A
+record may contain the earlier `actions`/`parents` tree, the newer
+`nodes`/`edges` graph, or both. `VocabGraph::from_vocab` normalizes these forms
+into one read-side representation.
 
-- **Nodes** with a `kind` discriminator (`concept`, `relation`,
-  `instance`, `type`, `collection`).
-- **Edges** $(s, t, r)$ where $s$ and $t$ are node ids and $r$ is
-  a relation slug.
-- **Relation metadata** declaring algebraic properties of $r$.
-- **SKOS Core annotations** on every node.
-- **External-id mappings** for cross-system grounding.
+## From a tree to a relation graph
 
-The shape is modelled on `pub.chive.graph.{node,edge}`.
+In the earlier form, each action has zero or more parents. Normalization turns
+each action into a concept node and each parent pointer into a `subsumed_by`
+edge. If `docker-run` names `subprocess` as a parent, the normalized graph
+contains:
 
-## Why a graph, not a tree
+$$
+\operatorname{subsumed\_by}(\texttt{docker-run},\texttt{subprocess})
+$$
 
-Earlier idiolect releases shipped a single-relation tree (the
-`subsumed_by` parent pointer). That covers the canonical
-hierarchical case (a `docker-run` is a `subprocess`) but not:
+The graph form generalizes this arrangement by allowing multiple named
+relations over the same node set. A community can represent subsumption,
+equivalence, opposition, membership, or a domain-specific relation without
+adding a new field to every record that uses the vocabulary.
 
-- Multiple relations on the same nodes (`equivalent_to`,
-  `polar_opposite_of`, `instance_of`, `member_of`, ...).
-- Cross-vocabulary translation. A node in one vocab and a node in
-  another can be linked by `equivalent_to` so consumers can
-  follow the bridge.
-- Algebraic properties beyond reflexivity (`symmetric`,
-  `transitive`, `inverse_of`, ...). These are the OWL Lite
-  predicates.
+## Nodes and edges
 
-The graph form generalises the tree: `subsumed_by` is just one
-relation among many.
+A node requires only a stable `id`. Optional fields provide a kind, label,
+status, external identifiers, and human-facing annotations. The known node
+kinds are `concept`, `relation`, `instance`, `type`, and `collection`; the field
+itself uses `knownValues`, so other kind slugs remain valid strings.
 
-## Node kinds
+An edge is a triple $(s,r,t)$ consisting of a source id, relation slug, and
+target id. Relation-kind nodes may carry `relationMetadata`. The metadata uses
+property-characteristic names familiar from the
+[OWL 2 structural specification](https://www.w3.org/TR/owl2-syntax/), including
+`symmetric`, `asymmetric`, `transitive`, `reflexive`, `irreflexive`,
+`functional`, and `inverseFunctional`.
 
-| Kind | What it represents |
-| --- | --- |
-| `concept` | A SKOS concept; the typical case. |
-| `relation` | A relation type. The node carries the relation's metadata; edges of that kind reference this node by slug. |
-| `instance` | A specific entity (a `did`, an `at-uri`, a real-world identifier). |
-| `type` | A type-of-types; rare but useful for meta-vocabularies. |
-| `collection` | A SKOS Collection. Members are linked by `member_of` edges. |
+The resemblance is deliberately limited. A `dev.idiolect.vocab` record is not
+an OWL ontology, and `VocabGraph` is not an OWL reasoner. We call its supported
+behavior **relation-aware reachability (RAR)**.
 
-## OWL-Lite-style property characteristics
+## What RAR computes
 
-A `relation`-kind node carries metadata declaring the relation's
-algebraic properties. The shipped set follows the OWL Lite
-terminology adopted by the project; strictly, it spans both
-OWL Lite (`symmetric`, `transitive`, `functional`,
-`inverseFunctional`, `inverseOf`) and OWL 2 additions
-(`asymmetric`, `reflexive`, `irreflexive`).
+`walk_relation(source, relation, reflexive)` follows reachable edges for the
+named relation. It always follows paths to closure, regardless of the relation's
+`transitive` metadata. If the relation is marked `symmetric`, the walk follows
+both outgoing and incoming edges. If the caller sets `reflexive`, the result
+also contains the source.
 
-| Property | Meaning |
-| --- | --- |
-| `symmetric` | $r(a, b) \Rightarrow r(b, a)$ |
-| `asymmetric` | $r(a, b) \Rightarrow \lnot r(b, a)$ |
-| `transitive` | $r(a, b) \land r(b, c) \Rightarrow r(a, c)$ |
-| `reflexive` | $r(a, a)$ for all $a$ in scope |
-| `irreflexive` | $\lnot r(a, a)$ for all $a$ in scope |
-| `functional` | $r(a, b_1) \land r(a, b_2) \Rightarrow b_1 = b_2$ |
-| `inverseFunctional` | $r(a_1, b) \land r(a_2, b) \Rightarrow a_1 = a_2$ |
-| `inverseOf` | A pointer to the inverse relation node. |
-| `world` (per-relation override) | Open-enum policy for this relation only. |
+The convenience operations are defined in terms of that walk:
 
-Contradictions (`symmetric+asymmetric`, `reflexive+irreflexive`)
-are caught at validation time. Functional and inverse-functional
-violations are caught at edge-walk time. The `VocabGraph::validate`
-walker emits one
-[`VocabViolation`](../reference/crates/idiolect-records.md) per
-inconsistency.
+- `subsumed_by(source)` uses `subsumed_by` with reflexive reachability.
+- `is_subsumed_by(specific, general)` tests membership in that closure.
+- `direct_targets` and `direct_sources` return one-hop neighbors.
+- `equivalent_in(source, other)` searches `equivalent_to` reachability for a
+  node id known to the other graph.
+- `top` returns a unique non-relation root under `subsumed_by`, when one exists;
+  `top_with` gives an explicit record field priority.
 
-## SKOS Core annotations
+The current implementation stores `inverseOf` and per-relation `world` in the
+generated record type but does not apply them in `VocabGraph` traversal.
+Likewise, setting `reflexive` metadata does not force a walk to include its
+source; the call's `reflexive` argument controls that behavior. Consumers should
+not infer full OWL semantics from the serialized names.
 
-Every concept-kind node accepts the SKOS Core annotation set:
+## Validation boundary
 
-| Field | SKOS counterpart |
-| --- | --- |
-| `label` | `prefLabel` |
-| `alternateLabels` | `altLabel` |
-| `hiddenLabels` | `hiddenLabel` |
-| `description` | `definition` |
-| `scopeNote` | `scopeNote` |
-| `example` | `example` |
-| `historyNote` | `historyNote` |
-| `editorialNote` | `editorialNote` |
-| `changeNote` | `changeNote` |
-| `notation` | `notation` |
-| `externalIds[]` | `exactMatch` / `closeMatch` / `broadMatch` / `narrowMatch` / `relatedMatch` |
+`VocabGraph::validate` checks the constraints that can be established directly
+from the authored edges and metadata:
 
-The annotations do not affect runtime resolution (the slug is the
-key). They are surface area for human authors and downstream
-display tooling.
+1. functional relations have at most one target per source;
+2. inverse-functional relations have at most one source per target;
+3. irreflexive relations contain no self-loop;
+4. asymmetric relations contain no pair of reverse edges; and
+5. declarations do not combine `symmetric` with `asymmetric` or `reflexive`
+   with `irreflexive`.
 
-## Runtime queries
+The method reports `VocabViolation` values. It does not reject the record during
+deserialization, add missing closure edges, or establish that a label's intended
+meaning is correct. That division is the **validation boundary (VB)**:
+structural inconsistency is machine-checkable, while semantic trust remains
+consumer policy. At the VB, a clean graph is not yet a trustworthy vocabulary.
 
-`VocabGraph` is a normalised read-only view over a single vocab.
-The shipped methods on it:
+## Human-facing annotations
 
-- `walk_relation(source, relation, reflexive) -> Vec<String>` —
-  the canonical traversal primitive.
-- `subsumed_by(source) -> Vec<String>` — the transitive +
-  reflexive `subsumed_by` walk from `source`.
-- `is_subsumed_by(specific, general) -> bool` — the legacy
-  hierarchical query.
-- `direct_targets(source, relation) -> &[String]` and
-  `direct_sources(target, relation) -> &[String]` — one-hop
-  neighbours.
-- `equivalent_in(source, other) -> Option<String>` — find the
-  equivalent slug in another graph via `equivalent_to` edges.
-- `top()` / `top_with(explicit)` — the vocab's top node under
-  `subsumed_by`.
-- `relation_properties(relation) -> RelationProperties` — the
-  OWL Lite metadata for the named relation.
-- `validate() -> Vec<VocabViolation>` — the OWL Lite consistency
-  walker.
+The node fields `label`, `alternateLabels`, `hiddenLabels`, `description`,
+`scopeNote`, `example`, `historyNote`, `editorialNote`, `changeNote`, and
+`notation` are modeled after the
+[SKOS reference](https://www.w3.org/TR/skos-reference/). They provide
+authoring and display metadata, but the record is not serialized as RDF and
+the runtime does not enforce SKOS integrity conditions.
 
-`VocabRegistry` caches multiple graphs by AT-URI for
-cross-vocabulary work. It exposes:
+`externalIds` adds mappings to identifiers outside ATProto with a mapping type
+such as `exact`, `close`, `broader`, `narrower`, or `related`. These mappings are
+stored on normalized nodes only indirectly: the current `NormalizedNode` view
+does not expose `externalIds`. Callers that need them must inspect the generated
+`Vocab` record.
 
-- `insert(uri, &vocab)` / `get(uri)` / `len()` / `is_empty()` —
-  registry plumbing.
-- `is_subsumed_by(uri, specific, general) -> Option<bool>` and
-  `satisfies(uri, x, relation, y) -> Option<bool>` — query a
-  named vocab. `None` means the registry has no entry for that
-  URI.
-- `translate(from_uri, to_uri, slug) -> Option<String>` — walk
-  `equivalent_to` edges to translate a slug across vocabs.
-- `validate() -> BTreeMap<String, Vec<VocabViolation>>` — batch
-  validate every registered vocab.
+## Multiple vocabularies
 
-The exact signatures and return types are on docs.rs at
-[`idiolect_records::vocab::VocabGraph`](https://docs.rs/idiolect-records/latest/idiolect_records/vocab/struct.VocabGraph.html).
+`VocabRegistry` caches normalized graphs by caller-supplied URI string. It can
+test a relation in one registered graph or translate a slug between two graphs
+with `equivalent_in`. Translation succeeds when the target graph already knows
+the slug or when `equivalent_to` reachability produces a node id that the target
+knows.
 
-## Cross-vocab translation
+This operation is pairwise. It does not search an arbitrary network of
+vocabulary records, fetch missing records, or select which publisher is
+authoritative. A consumer must load the two records, validate them, and decide
+that their equivalence declarations are acceptable.
 
-Two vocabs that publish `equivalent_to` edges between their nodes
-form an undirected bridge. A consumer holding both records and a
-`VocabRegistry` can ask:
+## Revision and supersession
 
-```rust
-let translated: Option<String> = registry.translate(
-    &from_uri,
-    &to_uri,
-    "agree", // a slug in the from-vocab
-);
-```
+A vocabulary record may point to a predecessor with `supersedes`. ATProto still
+allows a publisher to update a record at the same AT-URI, producing a new CID,
+or to create a record at a new key. The Lexicon does not require one revision
+strategy. Consumers that need an immutable vocabulary revision should retain a
+strong reference or otherwise pin the CID rather than relying on the AT-URI
+alone.
 
-If the bridge exists, the consumer gets the equivalent slug in
-the target vocab. If it does not, `None`. This is what backs
-[Open enums](./open-enums.md)' `translate_to` helper.
-
-## Versioning
-
-A vocab edit is a record edit (a new `dev.idiolect.vocab` record)
-under a new rkey, with the old vocab listed as `supersedes`. The
-new record is a separate at-uri. Consumers depending on the old
-slug set continue to resolve through the old vocab until they
-update their references.
-
-The lexicon-evolution policy classifies vocab edits the same way
-it classifies schema edits:
-
-- Adding a node or an edge — Iso (open enums tolerate).
-- Renaming a node — Iso via `RenameEdgeName`.
-- Removing a node — Projection over consumers using that node.
-- Adding `equivalent_to` between two vocabs — derives a free lens
-  available through the orchestrator's `mapEnum` cache.
-
-The full classification is in
-[Lexicon evolution policy](./lexicon-evolution.md).
+[Open enums and vocabularies](./open-enums.md) explains how generated slug types
+call into these graph operations. The [vocabulary guide](../guide/vocabulary.md)
+covers record authoring.

--- a/docs/book/src/concepts/why-idiolect.md
+++ b/docs/book/src/concepts/why-idiolect.md
@@ -1,109 +1,87 @@
 # Why idiolect exists
 
-This chapter states the problem the project addresses and how the
-machinery responds to it, without formalism. The rest of the
-Concepts section assumes it.
+idiolect addresses the **private-converter problem (PCP)**: independently
+written schema converters tend to remain inside the applications that need
+them, so later consumers cannot inspect, reuse, or evaluate the translation
+knowledge they contain.
 
-## Two apps, one firehose
+## Two event schemas
 
-Suppose two communities build event-planning apps on ATProto.
+Suppose two communities build event-planning applications on ATProto. One
+publishes `garden.seedling.event`, with `title`, `startsAt`, and a free-text
+`where` field. The other publishes `club.lantern.gathering`, with `name`,
+`beginsAt`, and a structured `venue` object. Each schema fits its application.
 
-One community ships a lexicon called `garden.seedling.event`. Its
-records have a `title`, a `startsAt`, and a free-text `where`
-field. The other community ships `club.lantern.gathering`. Its
-records have a `name`, a `beginsAt`, and a structured `venue`
-object. Neither community did anything wrong. Each schema fits its
-app, each shipped when it was ready, and neither had any reason to
-wait for the other.
+A calendar aggregator that consumes both collections now has to answer three
+questions: which fields correspond, what happens to information that exists on
+only one side, and whose answer should be trusted? ATProto supplies publication,
+identity, and repository proofs. It does not supply the correspondence between
+these two Lexicons.
 
-Now a third developer builds a calendar aggregator, whose premise
-is that every event on the network appears in it. The
-aggregator subscribes to the firehose and immediately faces the
-problem this project exists for: the network has two shapes for
-the same kind of thing, and nothing on the network says how they
-relate.
+## Why local fixes accumulate poorly
 
-## The options that do not scale
+The aggregator can hard-code two adapters. That solves its immediate problem,
+but another consumer must repeat the work, and neither consumer has a common
+object on which to publish tests or corrections. Supporting one schema only
+avoids translation by excluding data. Asking both communities to adopt a third
+schema may be appropriate in some settings, though it shifts the disagreement
+to standard selection.
 
-The aggregator developer has three obvious moves, and each one
-fails in a characteristic way.
+These responses differ operationally, but they leave the PCP intact: knowledge
+of the relationship is either private or absent.
 
-**Hardcode both.** Write an internal converter from each lexicon
-into the aggregator's own model. This works for the aggregator,
-for these two lexicons, for now. But the work is private: the next
-consumer rewrites the same converters, every schema revision
-breaks them silently, and the effort grows with the product of
-consumers and lexicons.
+## The publication move
 
-**Pick a winner.** Support `garden.seedling.event` and ignore the
-other. Half the network's events vanish, and the aggregator has
-quietly become a standards body, the thing a federated network
-was supposed to avoid.
+idiolect makes a translation publishable. A panproto
+[lens](../glossary.md#lens "A bidirectional schema translation with explicit round-trip obligations")
+record names its source and target schemas and carries a schema-parameterized
+translation body. A consumer can resolve that record, instantiate it under the
+ATProto protocol, and apply it to a source value. If `get` drops `where` while
+constructing `venue`, its complement retains the discarded state for `put`.
 
-**Wait for a standard.** Petition both communities to converge on
-a shared lexicon. Sometimes this works. Usually it produces a
-third lexicon.
+Publication creates a shared object, not automatic trust. The record family
+thus separates four kinds of claim:
 
-The pattern in all three failures is the same: the *knowledge of
-how two schemas relate* stays private, so the network cannot
-accumulate it.
+1. A `dev.idiolect.verification` reports the result of running a named check on
+   a lens.
+2. A `dev.idiolect.recommendation` endorses a lens path under stated conditions
+   and caveats.
+3. A `dev.idiolect.encounter` records an invocation; a correction or later
+   observation can qualify that evidence.
+4. A `dev.idiolect.dialect` bundles the schema references that constitute a
+   community's idiolect set, along with preferred lenses and deprecations.
 
-## The move idiolect makes
+This separation is the **evidence split (ES)**. A lens body says how to
+translate; a verification says what a particular runner observed; a
+recommendation says who advises using the lens and when. Under the ES, no one
+record stands in for the others.
 
-idiolect's answer is to make that knowledge a first-class,
-published, verifiable object. Anyone (either community, the
-aggregator developer, or an uninvolved third party) can publish a
-*lens*: a two-way translation between the two lexicons, itself a
-signed record on the network. The aggregator resolves the lens and
-applies it instead of hand-writing a converter. So does every
-consumer after it.
+## What the model can promise
 
-A published translation raises an obvious question: why trust it?
-idiolect's answer is more records. A *verification* record is a
-machine-checked run of the lens against real data: evidence, not
-prose. A *recommendation* record is a party endorsing a lens for a
-purpose. A *dialect* record is a community bundling its preferred
-lexicons and lenses so consumers can adopt its choices wholesale.
-None of these requires a central registry. Trust accumulates the
-way it does between people: through use, attestation, and
-reputation, all of it auditable.
+The runtime can preserve unfamiliar open-enum slugs, reject values that its
+typed decoders cannot parse, apply a resolved lens, and publish the resulting
+evidence records. A corpus-backed verification may show that a round-trip law
+held for the tested corpus. It does not prove that the law holds for every
+possible record, and a signed repository commit proves authorship and integrity
+rather than semantic correctness.
 
-The linguistic framing follows from this picture. Each party's
-schema choices are its *idiolect*;
-a community's endorsed bundle is a *dialect*; the federated
-substrate where they meet and negotiate is the *language*. The
-[next chapter](./idiolect-dialect-language.md) develops the frame
-and, importantly, the failure modes it admits.
+idiolect consequently does not promise a global schema, universal convergence,
+or trustworthy publishers. It provides objects over which communities can make
+translation, evidence, and policy disagreements explicit. The
+[idiolect/dialect/language frame](./idiolect-dialect-language.md) names the three
+levels at which those disagreements arise.
 
-## The example, mapped to the machinery
+## From the example to the runtime
 
-Each element of the example above corresponds to one lexicon or
-concept in the runtime:
-
-| In the example | Machinery |
+| Question from the example | Runtime object |
 | --- | --- |
-| The published translation | A panproto lens record; see [Lens semantics and laws](./lens-laws.md) |
-| Evidence the translation works | `dev.idiolect.verification`; see [the tutorial's verification step](../tutorial/04-verify.md) |
-| An endorsement | `dev.idiolect.recommendation` |
-| A community's bundled choices | `dev.idiolect.dialect`; see [Bundle records into a dialect](../guide/dialect.md) |
-| Noticing that two schemas coexist | `dev.idiolect.encounter` / `dev.idiolect.observation`; see [Observer protocol](./observer.md) |
-| Arguing about what to converge on | The deliberation lexicons; see [Deliberation](./deliberation.md) |
+| How do the two event shapes correspond? | `dev.panproto.schema.lens` and [lens semantics](./lens-laws.md) |
+| Did a check find a counterexample? | `dev.idiolect.verification` |
+| Who recommends this path, and under which conditions? | `dev.idiolect.recommendation` |
+| What happened when a consumer used it? | `dev.idiolect.encounter`, `correction`, and `observation` |
+| Which choices does a community currently prefer? | `dev.idiolect.dialect` |
+| How can a community debate a choice before adopting it? | The [deliberation records](./deliberation.md) |
 
-## What idiolect does not promise
-
-idiolect does not promist: (i) a single canonical schema; (ii) a global arbiter; 
-or (iii) a guarantee of convergence. Two communities may stay incompatible forever; the
-frame makes that visible (no lens between them, no
-recommendations) rather than impossible. What is promised is
-narrower and checkable: published lenses obey stated laws, records
-under one NSID share one wire shape, and lexicon revisions ship
-with auditable migrations. [Idiolect, dialect,
-language](./idiolect-dialect-language.md) states these promises
-and non-promises precisely.
-
-## Where next
-
-- [What you need first](./prerequisites.md) gives the assumed
-  background.
-- The [tutorial](../tutorial/index.md) walks the full loop on real
-  records: fetch, validate, apply a lens, verify, publish.
+For the operational loop, continue with the [tutorial](../tutorial/index.md).
+For the conceptual division of responsibility, continue with
+[Idiolect, dialect, language](./idiolect-dialect-language.md).

--- a/docs/book/src/glossary.md
+++ b/docs/book/src/glossary.md
@@ -1,0 +1,201 @@
+# Glossary
+
+This glossary gives the short definitions used throughout the book. Entries for
+named standards link to their normative specification or the standard's official
+project documentation.
+
+## AT Protocol
+
+[AT Protocol](https://atproto.com/specs/atp), usually shortened to **ATProto** or
+**atproto**, is the federated protocol on which idiolect publishes records and
+services.
+
+## AT URI
+
+An [AT URI](https://atproto.com/specs/at-uri-scheme) identifies an ATProto
+repository or record with an authority, an optional collection, and an optional
+record key. An AT URI is mutable unless paired with a CID.
+
+## Catalog
+
+The **catalog** is the orchestrator's indexed store of typed idiolect records.
+Queries evaluate over this local read model; the catalog is not a global
+registry or an authority over the records it contains.
+
+## CID
+
+A [Content Identifier (CID)](https://github.com/multiformats/cid) is a
+self-describing content address built from a cryptographic hash and format
+metadata. ATProto uses CIDs for links whose target bytes must be verifiable.
+
+## Complement
+
+A **complement** stores source information that a lens cannot reconstruct from
+its view alone. A `put` operation uses that information when it propagates an
+edited view back to the source schema.
+
+## DID
+
+A [decentralized identifier
+(DID)](https://www.w3.org/TR/did-core/) is a URI that identifies an entity and
+resolves according to a DID method. ATProto accounts use DIDs as stable account
+identifiers even when handles or hosting providers change.
+
+## Dialect
+
+A **dialect** is a community's published bundle of preferred schemas, lenses,
+and deprecations. It records a collective convention without making that
+convention global.
+
+## DPoP
+
+[Demonstrating Proof of Possession
+(DPoP)](https://www.rfc-editor.org/rfc/rfc9449.html) binds an OAuth token to a
+client-held key. The ATProto OAuth profile requires DPoP with server-issued
+nonces.
+
+## Encounter
+
+An **encounter** is a signed record of one lens invocation, including the lens,
+the source and target schemas, the purpose, and the observed outcome.
+
+## Firehose
+
+An ATProto **firehose** is the repository event stream described by the
+[ATProto synchronization specification](https://atproto.com/specs/sync). PDSs
+emit events for hosted accounts; relays may aggregate many upstream streams.
+
+## Idiolect
+
+An **idiolect** is one party's choice of schemas, lenses, vocabularies, and
+conventions. The term names the local unit of variation that idiolect preserves.
+
+## Language
+
+A **language**, in this book's three-level model, is the federated substrate on
+which idiolects and dialects interact. It does not denote one centrally managed
+schema catalog.
+
+## Lens
+
+A **lens** is a bidirectional translation between a source schema and a target
+schema. Its `get` operation produces a target view; its `put` operation
+propagates edits to that view back to the source, subject to stated lens laws.
+
+## Lexicon
+
+[Lexicon](https://atproto.com/specs/lexicon) is ATProto's schema language for
+records, XRPC endpoints, and event-stream messages. Each Lexicon file is named by
+an NSID.
+
+## Lexicon family
+
+<a id="record-family"></a>
+
+A **Lexicon family**, also called a **record family** in generated APIs, is the
+set of related Lexicon records emitted and versioned together under one namespace
+policy.
+
+## NSID
+
+A [Namespaced Identifier (NSID)](https://atproto.com/specs/nsid) is a global
+semantic identifier whose authority appears in reverse-domain order, followed by
+a final name segment. `dev.idiolect.belief` is an NSID.
+
+## Observation
+
+An **observation** is a signed aggregate computed from a stated scope of
+encounters by a named observer method. It is evidence produced by a method, not
+the raw trace of a single translation.
+
+## Observer
+
+An **observer** consumes encounter or record data, applies a declared method, and
+publishes observations. The method and its inputs remain inspectable so consumers
+can evaluate the result.
+
+## Open enum
+
+An **open enum** accepts a known set of values while preserving unknown strings.
+This representation lets older consumers retain values added by later producers.
+
+## OAuth
+
+[OAuth](https://atproto.com/specs/oauth) is the authorization framework ATProto
+clients use to obtain scoped access to PDS resources. The ATProto profile
+combines OAuth with PKCE, PAR, and DPoP requirements.
+
+## Panproto
+
+[Panproto](https://github.com/panproto/panproto) supplies the schema graphs,
+protocols, protolenses, lens runtime, compatibility checks, and parsing machinery
+that idiolect uses. This book targets Panproto 0.70.1.
+
+## PDS
+
+A [Personal Data Server
+(PDS)](https://atproto.com/specs/account) hosts ATProto accounts, repositories,
+authentication, and blobs. An account may migrate between PDS providers without
+changing its DID.
+
+## Protocol
+
+A **protocol**, in Panproto's formal model, supplies operations and laws against
+which schemas and lenses can be interpreted. This use is narrower than “network
+protocol.”
+
+## Protolens
+
+A **protolens** is Panproto's schema-level description of a bidirectional
+transformation before that description is instantiated as a runtime lens.
+
+## Recommendation
+
+A **recommendation** is a community's signed endorsement of particular schemas or
+lenses, optionally conditioned on verifications. It records social authority and
+does not itself prove a mechanical property.
+
+## Record
+
+An ATProto **record** is a typed data object stored in an account repository. Its
+`$type` value names the governing Lexicon schema, and its collection is normally
+the same NSID.
+
+## Repository
+
+An ATProto **repository** is an account's signed, content-addressed collection
+of records. A PDS stores the repository and distributes its commits through the
+ATProto synchronization protocol.
+
+## Schema
+
+A **schema** describes the admissible structure of a record. Idiolect reads
+ATProto Lexicons into Panproto schema graphs for validation, comparison, and lens
+execution.
+
+## Strong reference
+
+An ATProto **strong reference** pairs an AT URI with the target record's CID. The
+URI locates the record and the CID identifies the exact content.
+
+## Theory
+
+A **theory** is a named collection of formal structure and constraints used to
+compose Panproto schemas. Idiolect's theory files state reusable semantic
+components rather than runtime records.
+
+## Verification
+
+A **verification** is a signed report that a named runner checked a particular
+property of a lens and obtained `holds`, `falsified`, or `inconclusive`.
+
+## Vocabulary
+
+A **vocabulary** is a governed graph of concepts and relations that record fields
+may reference. Values remain ordinary identifiers; the vocabulary supplies their
+machine-readable relations and provenance.
+
+## XRPC
+
+[Lexicon RPC (XRPC)](https://atproto.com/specs/xrpc) is ATProto's convention for
+HTTP query and procedure endpoints named by NSIDs.

--- a/docs/book/src/glossary.md
+++ b/docs/book/src/glossary.md
@@ -129,7 +129,7 @@ combines OAuth with PKCE, PAR, and DPoP requirements.
 
 [Panproto](https://github.com/panproto/panproto) supplies the schema graphs,
 protocols, protolenses, lens runtime, compatibility checks, and parsing machinery
-that idiolect uses. This book targets Panproto 0.70.1.
+that idiolect uses. This book targets Panproto 0.71.0.
 
 ## PDS
 

--- a/docs/book/src/guide/codegen.md
+++ b/docs/book/src/guide/codegen.md
@@ -1,10 +1,9 @@
 # Run codegen
 
-Codegen keeps the lexicons (under `lexicons/dev/idiolect/`) the
-single source of truth. Anything that lives downstream of a
-lexicon (Rust types, TypeScript validators, family modules,
-spec-driven HTTP routes and CLI subcommands) is regenerated, not
-hand-edited.
+Codegen treats the [lexicons](../glossary.md#lexicon "A schema document in the AT Protocol Lexicon language")
+under `lexicons/dev/idiolect/` as its source of truth. Regenerate
+derived Rust types, TypeScript validators, family modules, HTTP
+routes, and CLI dispatch after changing that source.
 
 The crate is
 [`idiolect-codegen`](../reference/crates/idiolect-codegen.md).
@@ -17,9 +16,10 @@ cargo run -p idiolect-codegen           # write the generated tree
 cargo run -p idiolect-codegen -- --check # verify no drift
 ```
 
-The default mode regenerates. The `--check` flag re-derives in
-memory and byte-compares against the working tree, exiting
-non-zero on any drift. CI runs `--check` on every PR.
+The default mode writes the generated tree. The `--check` flag emits
+in memory, compares bytes against the working tree, and exits nonzero
+on drift. Both modes parse emitted Rust and TypeScript through
+panproto 0.70.1's tree-sitter gate before accepting the output.
 
 ## What gets emitted
 
@@ -37,12 +37,13 @@ non-zero on any drift. CI runs `--check` on every PR.
 The three spec files are single JSON documents (not directories).
 Each declares an array of entries that codegen reads.
 
-## The drift gate
+## Check for generated drift
 
-`--check` is the drift gate. CI runs it on every PR. A red gate
-means somebody edited a lexicon (or a spec) without rerunning
-the default mode, or hand-edited a generated file. Both are
-fixable by running `cargo run -p idiolect-codegen`.
+`--check` compares generated output with the checked-in tree. A failure usually
+means that a lexicon or
+spec changed without regeneration, or that a generated file was
+edited by hand. Run the default mode, inspect the resulting diff, and
+then run `--check` again.
 
 ## Adding a new lexicon
 
@@ -53,9 +54,10 @@ fixable by running `cargo run -p idiolect-codegen`.
    `examples` module emits a typed accessor.
 4. Re-run the workspace tests to confirm the family round-trips.
 
-The codegen rejects malformed lexicons (NSID violations,
-unresolved references) before emitting, so a broken lexicon
-errors at this step rather than at compile time.
+Codegen rejects malformed lexicons, including invalid
+[NSIDs](../glossary.md#nsid "A reverse-DNS identifier for an AT Protocol schema or method"),
+before it writes output. The subsequent emit gate rejects malformed
+generated source.
 
 ## Adding a new spec entry
 
@@ -69,24 +71,24 @@ specs each carry a different shape. The pattern is the same:
    an observer method, the `VerificationRunner` impl for a
    verifier runner).
 
-The dispatcher routes to the new entry by its kind. The
-generated tree handles parsing and shape.
+The dispatcher routes by the declared kind; the generated tree owns
+the parser and dispatch table.
 
 ## Library API
 
 For consumers outside the workspace, the emitter is callable as
 a library:
 
-```rust
+```text
 use idiolect_codegen::emit::{emit_rust, emit_typescript};
 use idiolect_codegen::emit::family::{FamilyConfig, idiolect_family};
 ```
 
 `emit_rust(docs, examples, family)` and
-`emit_typescript(docs, examples, family)` take pre-loaded
-`LexiconDoc` and `Example` slices plus a `FamilyConfig`, and
-return a `Vec<EmittedFile>`. Loading the lexicons from disk is
-the caller's job.
+`emit_typescript(docs, examples, family)` take preloaded
+`LexiconDoc` and `Example` slices plus `&FamilyConfig`. Each returns
+`anyhow::Result<Vec<EmittedFile>>`; loading lexicons from disk remains
+the caller's responsibility.
 
 `FamilyConfig::new(marker_name, id, nsid_prefix)` constructs a
 config from any string-like inputs. The shipped default for

--- a/docs/book/src/guide/codegen.md
+++ b/docs/book/src/guide/codegen.md
@@ -19,7 +19,7 @@ cargo run -p idiolect-codegen -- --check # verify no drift
 The default mode writes the generated tree. The `--check` flag emits
 in memory, compares bytes against the working tree, and exits nonzero
 on drift. Both modes parse emitted Rust and TypeScript through
-panproto 0.70.1's tree-sitter gate before accepting the output.
+panproto 0.71.0's tree-sitter gate before accepting the output.
 
 ## What gets emitted
 

--- a/docs/book/src/guide/dialect.md
+++ b/docs/book/src/guide/dialect.md
@@ -1,9 +1,9 @@
 # Bundle records into a dialect
 
-A `dev.idiolect.dialect` record is a community-published bundle
-of "these are the schemas, lenses, and conventions we treat as
-canonical". Consumers wanting the dialect's view of the world
-fetch one record and follow the references.
+A `dev.idiolect.dialect` record publishes a community's selected
+[schemas and lenses](../glossary.md#dialect "A community-selected bundle of schemas and translations")
+as one versioned bundle. A consumer fetches the record and follows
+only the references its local policy accepts.
 
 The shape is documented in the
 [lexicon reference](../reference/lexicons/dialect.md). The
@@ -20,9 +20,8 @@ fields most consumers care about:
 
 The shortest path is to construct the typed record directly:
 
-```rust
-use idiolect_records::{Dialect, AtUri, Datetime};
-// Plus the inline `defs` types: SchemaRef, LensRef, Deprecation.
+```text
+use idiolect_records::{AtUri, Datetime, Dialect};
 
 let dialect = Dialect {
     owning_community: AtUri::parse(
@@ -30,12 +29,12 @@ let dialect = Dialect {
     )?,
     name: "tutorial canonical".into(),
     description: Some("...".into()),
-    idiolects: vec![/* schemaRef entries */],
-    preferred_lenses: vec![/* lensRef entries */],
-    deprecations: vec![],
+    idiolects: Some(vec![/* SchemaRef values */]),
+    preferred_lenses: Some(vec![/* LensRef values */]),
+    deprecations: None,
     version: Some("1.0.0".into()),
     previous_version: None,
-    created_at: Datetime::parse("2026-04-19T00:00:00.000Z").unwrap(),
+    created_at: Datetime::parse("2026-04-19T00:00:00.000Z")?,
 };
 ```
 
@@ -44,35 +43,30 @@ Construct the record, then publish it via
 
 ## What it does for consumers
 
-Consumers reading a dialect get three things:
+Consumers reading a dialect get three independent signals:
 
 - A canonical NSID list. A consumer that has resolved a dialect
   knows which schemas the community treats as canonical and can
   filter incoming records accordingly.
-- A vocabulary registry by reference. Open-enum slugs in records
-  whose author belongs to the community resolve against the
-  dialect's listed vocabularies (consumers read the vocabularies
-  themselves through their `*Vocab` siblings, not through the
-  dialect).
+- A lens preference list. `preferredLenses` records which
+  translations the community recommends; it does not override a
+  consumer's trust policy.
 - An audit trail of deprecations. A consumer that sees a
   `Deprecation` entry can keep reading the deprecated NSID for
   some grace period and route to `replacement` afterwards.
 
 ## Use a dialect at runtime
 
-There is no shipped `DialectClient` helper. Consumers fetch the
-dialect record (via `idiolect_lens::PdsResolver`'s
-`Resolver::resolve` or any other resolver) and walk the typed
-fields directly. A small wrapper layer is the right shape if a
-consumer wants a `dialect.preferred_lens_for(nsid)` style
-accessor. The runtime ships only the record.
+There is no shipped `DialectClient`. Fetch the record through a typed
+record client and inspect its fields directly. The
+`idiolect_lens::Resolver` trait resolves lens records only; it does
+not resolve `dev.idiolect.dialect` records.
 
 ## Multiple dialects
 
-Two communities can publish disjoint, overlapping, or
-contradictory dialects. The protocol treats them all as opinions
-and prefers none. Consumers
-pick a resolution policy in their own code:
+Two communities may publish disjoint, overlapping, or contradictory
+dialects. The protocol assigns no global priority, so consumers pick
+a resolution policy in application code:
 
 - *first-match* — pick the first dialect listed in the
   consumer's config.

--- a/docs/book/src/guide/index-firehose.md
+++ b/docs/book/src/guide/index-firehose.md
@@ -1,7 +1,8 @@
 # Index a firehose
 
-[`idiolect-indexer`](../reference/crates/idiolect-indexer.md) is
-a firehose consumer factored into three trait surfaces:
+[`idiolect-indexer`](../reference/crates/idiolect-indexer.md) composes
+three boundaries around an AT Protocol
+[firehose](../glossary.md#firehose "A stream of repository commit events"):
 
 - `EventStream`: yields `RawEvent`s from a PDS firehose. Shipped
   impls: `JetstreamEventStream` (Jetstream websocket feed) and
@@ -29,7 +30,6 @@ use idiolect_records::IdiolectFamily;
 
 struct PrintHandler;
 
-#[async_trait::async_trait]
 impl RecordHandler<IdiolectFamily> for PrintHandler {
     async fn handle(
         &self,
@@ -42,7 +42,9 @@ impl RecordHandler<IdiolectFamily> for PrintHandler {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let mut stream = JetstreamEventStream::connect("wss://...").await?;
+    let mut stream = JetstreamEventStream::connect(
+        "wss://jetstream2.us-east.bsky.network/subscribe?wantedCollections=dev.idiolect.*",
+    ).await?;
     let cursors = FilesystemCursorStore::open("./cursor.json")?;
     let handler = PrintHandler;
     let config = IndexerConfig::default();
@@ -57,6 +59,8 @@ Add features:
 ```bash
 cargo add idiolect-indexer \
   --features firehose-jetstream,cursor-filesystem,reconnecting
+cargo add anyhow tracing-subscriber
+cargo add tokio --features macros,rt-multi-thread
 ```
 
 `reconnecting` wraps the inner stream in an exponential-backoff
@@ -72,7 +76,7 @@ decode, so an upstream PDS adding a record type ahead of your
 codegen run does not halt the loop. To handle two families
 (idiolect plus a downstream community's lexicons), compose:
 
-```rust
+```text
 use idiolect_records::{IdiolectFamily, OrFamily};
 
 struct MyFamily;
@@ -81,7 +85,7 @@ struct MyFamily;
 let handler: MyHandler<OrFamily<IdiolectFamily, MyFamily>> = ...;
 ```
 
-`OrFamily<F1, F2>` recognises every NSID either side claims. Its
+`OrFamily<F1, F2>` recognizes every NSID either side claims. Its
 `AnyRecord` is `OrAny`, a tagged union over the two halves.
 `detect_or_family_overlap` audits a probe set at boot so a
 configuration mistake does not silently shadow the right-side
@@ -91,10 +95,10 @@ family.
 
 `drive_indexer` calls
 `CursorStore::commit(subscription_id, seq)` after the handler
-returns `Ok`. A handler that wants at-least-once semantics
-should make its work idempotent before returning. A handler
-that wants exactly-once semantics needs to coordinate the commit
-with its own storage transaction.
+returns `Ok`. Make handler work idempotent to obtain at-least-once
+processing across restarts. Exactly-once processing requires a custom
+driver that commits application state and the cursor in one storage
+transaction; `drive_indexer` cannot make those writes atomic.
 
 Errors propagate as `IndexerError`. The variants distinguish
 transport failures (`Stream`), decode failures (`Decode`),
@@ -108,7 +112,7 @@ handler-defined errors (`Handler`), missing-body events
 Every shipped surface logs through `tracing`. Wire a
 subscriber:
 
-```rust
+```text
 tracing_subscriber::fmt()
     .with_env_filter("idiolect_indexer=info")
     .init();

--- a/docs/book/src/guide/index.md
+++ b/docs/book/src/guide/index.md
@@ -1,8 +1,24 @@
 # Guides
 
-Each guide answers one question of the form "how do I do X?". They
-assume you have read the [Tutorial](../tutorial/index.md) (or are
-comfortable working without it) and have the runtime installed.
+The guides start from an integration task and end with an operational
+result. If you have not yet resolved and translated a record, begin
+with the [tutorial](../tutorial/index.md).
+
+## Project-integration path
+
+For a first application, take these steps in order:
+
+1. [Index a firehose](./index-firehose.md) into your own handler and
+   choose a cursor store.
+2. [Run the orchestrator HTTP API](./orchestrator.md) over the indexed
+   catalog.
+3. [Configure authenticated sessions](./oauth.md) before adding a
+   record-publishing path.
+
+This path connects the read side, query side, and authenticated write
+side without changing the function of any individual guide.
+
+## Task index
 
 | Guide | When to reach for it |
 | --- | --- |
@@ -16,3 +32,6 @@ comfortable working without it) and have the runtime installed.
 | [Run codegen](./codegen.md) | You edited a lexicon or a spec and need the generated tree refreshed. |
 | [Author a community vocabulary](./vocabulary.md) | You want to extend an open enum or publish a typed knowledge graph. |
 | [Bundle records into a dialect](./dialect.md) | You want to ship a coherent set of idiolects as one canonical bundle. |
+
+For extension traits, feature flags, wire shapes, and endpoint
+parameters, use the [advanced reference path](../reference/index.md#extension-and-api-path).

--- a/docs/book/src/guide/migrate.md
+++ b/docs/book/src/guide/migrate.md
@@ -63,6 +63,10 @@ schema hashes, a `protolens_chain`, and an `alignment_quality` score.
 It returns `NoChange` or `OnlyNonBreaking` when a migration plan is
 unnecessary.
 
+Panproto 0.71.0 computes this alignment with an exact valued-CSP optimizer.
+The score orders alternatives for the same source schema; do not treat a fixed
+number as a confidence threshold across unrelated schema pairs.
+
 For breaking diffs that resist automation,
 `plan_auto` returns `Err(PlannerError::NotAutoDerivable)`
 listing the offending changes. The caller writes the lens by

--- a/docs/book/src/guide/migrate.md
+++ b/docs/book/src/guide/migrate.md
@@ -1,9 +1,8 @@
 # Migrate records across a revision
 
-A schema you depend on changed. You have records on disk against
-the old schema and need them up against the new one. This is
-what [`idiolect-migrate`](../reference/crates/idiolect-migrate.md)
-is for.
+Use [`idiolect-migrate`](../reference/crates/idiolect-migrate.md)
+when a [schema](../glossary.md#schema "A machine-readable description of valid data")
+revision no longer accepts records written against its predecessor.
 
 The crate is a thin typed façade over `panproto-check` (for diff
 classification) and `idiolect-lens` (for record translation). It
@@ -32,11 +31,12 @@ the reverse direction reconstructs the original.
 
 Before generating a lens, classify what changed:
 
-```rust
-use idiolect_migrate::{classify, plan_auto};
-use panproto_schema::Schema;
+```text
+use idiolect_migrate::classify;
+use panproto_schema::Protocol;
 
-let report = classify(&schema_v1, &schema_v2)?;
+let protocol = Protocol::default();
+let report = classify(&schema_v1, &schema_v2, &protocol);
 ```
 
 `classify` returns a `CompatReport` (re-exported from
@@ -48,13 +48,20 @@ v1 remain valid under v2.
 
 For breaking diffs that are covered by shipped recipes:
 
-```rust
-let plan = plan_auto(&schema_v1, &schema_v2, &hints)?;
+```text
+let plan = plan_auto(
+    &schema_v1,
+    &schema_v2,
+    &protocol,
+    source_schema_hash,
+    target_schema_hash,
+)?;
 ```
 
-`plan_auto` returns a `MigrationPlan` carrying the source and
-target schema hashes plus a lens body the caller can publish as
-a `dev.panproto.schema.lens` record.
+`plan_auto` returns a `MigrationPlan` carrying the two caller-supplied
+schema hashes, a `protolens_chain`, and an `alignment_quality` score.
+It returns `NoChange` or `OnlyNonBreaking` when a migration plan is
+unnecessary.
 
 For breaking diffs that resist automation,
 `plan_auto` returns `Err(PlannerError::NotAutoDerivable)`
@@ -63,20 +70,21 @@ hand.
 
 ## Migrate one record
 
-```rust
+```text
 use idiolect_migrate::migrate_record;
 
 let migrated_body = migrate_record(
-    &lens_record,        // PanprotoLens record (from a published lens or local plan)
-    &source_record_body, // serde_json::Value
-    &schema_loader,      // anything implementing idiolect_lens::SchemaLoader
+    &resolver,
+    &schema_loader,
+    &protocol,
+    lens_uri,
+    source_record_body,
 ).await?;
 ```
 
-`migrate_record` wraps `idiolect_lens::apply_lens` for the
-one-shot case: given a lens, a source record body, and a schema
-loader that can resolve both schema hashes, it returns the
-migrated target body.
+`migrate_record` resolves `lens_uri`, loads its source and target
+schemas, and wraps `idiolect_lens::apply_lens`. It returns the target
+record body as `serde_json::Value`.
 
 ## Verify before cutting over
 
@@ -84,19 +92,18 @@ Migration without verification is a guess. Run the round-trip
 runner against a corpus before treating the migrated tree as
 authoritative:
 
-```rust
+```text
 use idiolect_verify::{RoundtripTestRunner, VerificationRunner, VerificationTarget};
 
-let runner = RoundtripTestRunner::new(/* ... */);
-let target = VerificationTarget {/* lens, corpus, schema loader, ... */};
+let runner = RoundtripTestRunner::new(resolver, schema_loader, protocol, corpus);
+let target = VerificationTarget { /* lens, verifier, occurred_at, tool_override */ };
 let verification = runner.run(&target).await?;
 ```
 
-A `Verification { result: Holds, .. }` over a representative
-corpus is the strongest signal you can get short of formal
-proof. The runner returns a `Verification` record that you can
-publish as a `dev.idiolect.verification` (via
-`idiolect_lens::RecordPublisher`).
+A `Verification { result: Holds, .. }` establishes only that the
+sampled corpus round-tripped. Record the corpus boundary, review any
+projection complement, and publish the result through
+`idiolect_lens::RecordPublisher` if other consumers need it.
 
 ## Persist the lens record
 
@@ -121,8 +128,9 @@ covers that case. The authoring loop is:
 5. Publish the chain plus a verification record signed by a
    reviewer.
 
-Each step is mechanical and gated. The policy makes migrations
-reviewable.
+The checklist records the authored chain, law checks, corpus run, and
+reviewer-signed verification, but the current repository does not enforce
+every gate automatically.
 
 ## Batch migration
 
@@ -139,7 +147,6 @@ idiolect-migrate \
    [--pds-url URL]
 ```
 
-Records stream one at a time so the working set stays bounded
-even on multi-million-record corpora. Failed migrations log to
-stderr and the binary's exit code reflects the worst case (0 if
-every file succeeded, 1 if any failed).
+Records stream one at a time, so memory use does not grow with the
+input directory. Failed migrations go to stderr; the process exits 1
+if any file fails and 0 otherwise.

--- a/docs/book/src/guide/oauth.md
+++ b/docs/book/src/guide/oauth.md
@@ -1,13 +1,10 @@
 # Configure OAuth sessions
 
-[`idiolect-oauth`](../reference/crates/idiolect-oauth.md)
-provides the token-store trait and three shipped implementations,
-plus a `refresh_if_needed` helper and a `Refresher` trait for
-session refresh. The crate does *not* implement the OAuth dance
-itself: that lives in `atrium-oauth-client`. Consumers drive the
-dance in their own code, then either call `refresh_if_needed` or
-read `OAuthSession`'s helpers (`is_expired`, `needs_refresh`,
-`refresh_expired`) to drive the refresh decision themselves.
+[`idiolect-oauth`](../reference/crates/idiolect-oauth.md) stores
+[OAuth](../glossary.md#oauth "An authorization framework for delegated access")
+sessions after an application completes the authorization flow. The
+crate supplies `OAuthTokenStore`, three stores, and refresh timing; an
+OAuth client supplies the network exchange.
 
 ## When you need it
 
@@ -23,27 +20,29 @@ authenticated PDS session. Reading records does not.
 | `FilesystemOAuthTokenStore` | `store-filesystem` | A single operator process running on one host. Sessions live under a directory; one file per DID. |
 | `SqliteOAuthTokenStore` | `store-sqlite` | Multi-process or multi-tenant deployments. Concurrent reads, fsync per write. |
 
-All three implement `OAuthTokenStore`. Anything that takes
-`Arc<dyn OAuthTokenStore>` accepts any of them.
+All three implement `OAuthTokenStore`. Its native async methods make
+the trait non-object-safe, so callers remain generic over
+`S: OAuthTokenStore` rather than using `Arc<dyn OAuthTokenStore>`.
 
 `idiolect-oauth` is `publish = false`; depend via git.
 
 ## Filesystem store
 
 ```toml
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0", features = ["store-filesystem"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["store-filesystem"] }
 ```
 
-```rust
+```text
 use idiolect_oauth::{FilesystemOAuthTokenStore, OAuthTokenStore};
 
-let store = FilesystemOAuthTokenStore::open("./sessions/")?;
+std::fs::create_dir_all("./sessions/")?;
+let store = FilesystemOAuthTokenStore::new("./sessions/")?;
 
 // Write a session (returned by the OAuth dance, not by this crate):
 store.save(&session).await?;
 
 // Read it back later:
-let recovered = store.load(&session.did).await?;
+let recovered = store.load(&session.did).await?; // Option<OAuthSession>
 ```
 
 The directory contains one JSON file per session keyed by DID.
@@ -51,20 +50,19 @@ The directory contains one JSON file per session keyed by DID.
 ## SQLite store
 
 ```toml
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0", features = ["store-sqlite"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["store-sqlite"] }
 ```
 
-```rust
+```text
 use idiolect_oauth::{SqliteOAuthTokenStore, OAuthTokenStore};
 
-let store = SqliteOAuthTokenStore::open("sessions.sqlite").await?;
+let store = SqliteOAuthTokenStore::open("sessions.sqlite")?;
 ```
 
 ## Drive the OAuth dance
 
-The dance itself is `atrium-oauth-client`'s job. The crate
-returns an authenticated session you store via
-`OAuthTokenStore::save`. The session shape (`OAuthSession`) is
+The authorization client returns an authenticated session that you
+store through `OAuthTokenStore::save`. The `OAuthSession` shape is
 documented in the crate's source: it carries the DID, PDS URL,
 access JWT, refresh JWT, DPoP private key (JWK-serialized),
 DPoP nonce, and expiry timestamps as public fields.
@@ -77,7 +75,9 @@ drives the refresh endpoint.
 
 ## DPoP
 
-The session's DPoP keypair is what binds the access token.
+The session's
+[DPoP](../glossary.md#dpop "Proof-of-possession binding for OAuth access tokens")
+keypair binds the access token.
 The signer (the `P256DpopProver` in
 [`idiolect-lens`](../reference/crates/idiolect-lens.md) under
 the `dpop-p256` feature) consumes the keypair from the session
@@ -105,12 +105,9 @@ idiolect oauth logout --did did:plc:...
 ```
 
 This path uses **app passwords in legacy Bearer mode**.
-ATProto is moving off app passwords in favour of OAuth +
-DPoP; the next-iteration login UX wraps `atrium-oauth`'s
-browser-handoff dance and persists the resulting DPoP-bound
-session through the same `OAuthTokenStore`. The `OAuthSession`
-shape already carries the DPoP private key field; switching
-flows is a CLI substitution, not a session-shape change.
+This CLI path is separate from `OAuthSession`: its JSON file contains
+the DID, handle, PDS URL, access JWT, and refresh JWT, but no DPoP key.
+Use the library store for a DPoP-bound OAuth deployment.
 
 ## `refresh_if_needed`
 
@@ -122,7 +119,7 @@ returns the live session. Callers who want to drive the
 decision themselves read `OAuthSession::needs_refresh` and
 `OAuthSession::is_expired` directly.
 
-```rust
+```text
 use idiolect_oauth::{refresh_if_needed, Refresher, RefreshError, OAuthSession};
 
 struct MyRefresher { /* http client, auth-server URL, ... */ }

--- a/docs/book/src/guide/oauth.md
+++ b/docs/book/src/guide/oauth.md
@@ -29,7 +29,7 @@ the trait non-object-safe, so callers remain generic over
 ## Filesystem store
 
 ```toml
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["store-filesystem"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["store-filesystem"] }
 ```
 
 ```text
@@ -50,7 +50,7 @@ The directory contains one JSON file per session keyed by DID.
 ## SQLite store
 
 ```toml
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["store-sqlite"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["store-sqlite"] }
 ```
 
 ```text

--- a/docs/book/src/guide/observer.md
+++ b/docs/book/src/guide/observer.md
@@ -1,9 +1,10 @@
 # Run the observer daemon
 
-The observer reads encounter-family records from the firehose,
-folds them through an `ObservationMethod`, and publishes a
-`dev.idiolect.observation` record on each flush. Observations
-are the durable summary; encounters are the event log.
+The observer folds records from a
+[firehose](../glossary.md#firehose "A stream of repository commit events")
+through an `ObservationMethod` and emits a
+`dev.idiolect.observation` at each configured flush. Encounters remain
+the event log; observations carry the computed summary.
 
 The crate is
 [`idiolect-observer`](../reference/crates/idiolect-observer.md).
@@ -18,13 +19,13 @@ A `dev.idiolect.observation` record carries:
   parameters and code reference),
 - a `scope` describing which records the aggregation covers,
 - the method's `output` payload (shape is method-defined),
-- a signature.
+- the observation's publication timestamp and visibility.
 
-The record kind is shared with deliberation tallies via the
-`deliberationOutcome` lexicon, but that is a separate
-record-kind, not an observation flavour.
+The `deliberation-tally` method currently places its result in
+`observation.output`; `dev.idiolect.deliberationOutcome` is a separate
+record kind.
 
-## Why the observer publishes records, not just metrics
+## Choose the publication boundary
 
 Observations are content-addressed and signed, like any other
 ATProto record. A consumer reading an observation can:
@@ -35,8 +36,8 @@ ATProto record. A consumer reading an observation can:
 - treat the observation as a soft assertion of fact, not a
   single source of truth.
 
-A central metrics endpoint cannot do that. The same record
-shape also lets multiple observers run in parallel and disagree.
+This record boundary lets several observers publish different folds
+without erasing the underlying events.
 
 ## Run the daemon
 
@@ -44,16 +45,23 @@ shape also lets multiple observers run in parallel and disagree.
 cargo install --path crates/idiolect-observer --features daemon
 ```
 
-The shipped binary's exact CLI surface is documented by its
-`--help`. It wires:
+The binary is configured through environment variables, not command
+flags. Set `IDIOLECT_OBSERVER_DID`; optionally set
+`IDIOLECT_TAP_URL`, `IDIOLECT_TAP_ADMIN_PASSWORD`,
+`IDIOLECT_OBSERVER_CURSORS`, `IDIOLECT_FLUSH_EVENTS`, and
+`IDIOLECT_PDS_URL`. It wires:
 
 - A firehose stream (tapped, via the indexer's
   `firehose-tapped` feature, transitively pulled in by
   `daemon`).
 - A SQLite cursor store.
-- An `ObserverHandler<M, P>` connecting an `ObservationMethod`
-  to an `ObservationPublisher`.
+- A `CorrectionRateMethod` inside `ObserverHandler<M, P>`.
 - A flush schedule that triggers observation publication.
+
+If `IDIOLECT_PDS_URL` is unset, the reference daemon uses an in-memory
+publisher and persists no observation records. Its PDS branch does not
+yet supply authentication; use a wrapper binary with an authenticated
+`PdsWriter` for production publication.
 
 ## Bundled methods
 
@@ -72,10 +80,9 @@ methods. Each lives in `crates/idiolect-observer/src/methods/`.
 | `attribution-chains` | `dev.idiolect.belief` counts by holder and subject. |
 | `deliberation-tally` | Per-statement per-stance `deliberationVote` counts (see the note below). |
 
-Methods come in two forms (declared in the spec): record-form
-methods consume `&IndexerEvent<IdiolectFamily>` directly;
-instance-form methods consume a panproto `WInstance` and wrap
-into the record form via `InstanceMethodAdapter`.
+The current spec declares all nine methods in record form; they consume
+`&IndexerEvent<IdiolectFamily>`. The library also supports instance-form
+methods over panproto `WInstance` through `InstanceMethodAdapter`.
 
 `default_methods()` returns boxed instances of every
 record-form method; instance-form methods need a caller-supplied
@@ -94,17 +101,15 @@ to the `default_methods()` constructor.
 
 - Observers should run with their own DID, distinct from the
   DIDs whose encounters they observe.
-- Multiple observers publishing observations of the same scope
-  is expected and useful; consumers can require quorum among $k$
-  of $n$ trusted observers before treating an observation as
-  authoritative.
+- Multiple observers may publish observations of the same scope.
+  Consumers can require quorum among $k$ of $n$ trusted observers
+  before treating an observation as authoritative.
 
-## Note on `deliberation-tally`
+## `deliberation-tally` output
 
 The shipped `deliberation-tally` method emits its
 per-statement per-stance vote counts inside an
 `observation.output` blob, not as a typed
 `dev.idiolect.deliberationOutcome` record. The data shape is
-the same; the surface differs. A variant that publishes the
-typed outcome record directly is a small refactor on top of
-the existing `DeliberationTallyMethod`.
+the same; the publication surface differs. Publishing a typed outcome
+requires separate application code.

--- a/docs/book/src/guide/orchestrator.md
+++ b/docs/book/src/guide/orchestrator.md
@@ -12,7 +12,7 @@ queries that same state.
 - `GET /metrics` — Prometheus exposition.
 - `GET /v1/stats` — record counts per kind.
 - One pair of REST and XRPC endpoints per declarative query in
-  `orchestrator-spec/queries.json`. The 0.11.1 surface includes:
+  `orchestrator-spec/queries.json`. The 0.12.0 surface includes:
   bounties (open, want-lens, by-requester), adapters (by
   framework, by invocation protocol, with verification),
   recommendations (starting from a source schema), verifications

--- a/docs/book/src/guide/orchestrator.md
+++ b/docs/book/src/guide/orchestrator.md
@@ -1,18 +1,18 @@
 # Run the orchestrator HTTP API
 
 [`idiolect-orchestrator`](../reference/crates/idiolect-orchestrator.md)
-is a read-only HTTP query API over a record catalog. It pairs
-with the indexer (which writes the catalog through
-`CatalogHandler`) and exposes the result over a small set of
-typed query endpoints.
+serves a read-only HTTP API over a record
+[catalog](../glossary.md#catalog "An indexed collection of AT Protocol records").
+`CatalogHandler` fills the catalog from the indexer; the HTTP server
+queries that same state.
 
 ## What it serves
 
 - `GET /healthz`, `GET /readyz` — liveness and readiness.
 - `GET /metrics` — Prometheus exposition.
 - `GET /v1/stats` — record counts per kind.
-- One endpoint per declarative query under
-  `orchestrator-spec/queries.json`. Snapshot at v0.8.0:
+- One pair of REST and XRPC endpoints per declarative query in
+  `orchestrator-spec/queries.json`. The 0.11.1 surface includes:
   bounties (open, want-lens, by-requester), adapters (by
   framework, by invocation protocol, with verification),
   recommendations (starting from a source schema), verifications
@@ -32,18 +32,21 @@ cargo install --path crates/idiolect-orchestrator \
     --features daemon
 ```
 
-The `daemon` feature pulls in `catalog-sqlite`, `query-http`,
-the indexer's tapped firehose, and the SQLite cursor store. Run:
+The `daemon` feature pulls in `catalog-sqlite`, `query-http`, the
+indexer's tapped firehose, and the SQLite cursor store. Configure and
+run it with environment variables:
 
 ```bash
-idiolect-orchestrator \
-  --catalog ./catalog.sqlite \
-  --bind 0.0.0.0:8787
+IDIOLECT_TAP_URL=http://localhost:2480 \
+IDIOLECT_ORCHESTRATOR_DB=./catalog.sqlite \
+IDIOLECT_ORCHESTRATOR_CURSORS=./cursors.sqlite \
+IDIOLECT_HTTP_ADDR=127.0.0.1:8787 \
+idiolect-orchestrator
 ```
 
-The exact CLI surface is documented by the daemon's `--help`.
-The catalog is populated by the indexer that ships with the
-daemon. The orchestrator reads from the same SQLite file.
+Set `IDIOLECT_TAP_ADMIN_PASSWORD` if the tap requires it and
+`IDIOLECT_SUBSCRIPTION_ID` when several subscriptions share a cursor
+database. The daemon does not parse `--catalog` or `--bind` flags.
 
 ## Query it
 
@@ -52,11 +55,11 @@ curl -s http://localhost:8787/v1/stats | jq
 curl -s 'http://localhost:8787/v1/bounties/open' | jq
 curl -s 'http://localhost:8787/v1/adapters?framework=hasura' | jq
 curl -s 'http://localhost:8787/v1/verifications?lens_uri=at://...' | jq
+curl -s 'http://localhost:8787/v1/verifications/sufficient?lens_uri=at://...&kinds=roundtrip-test&hold=true' | jq
 ```
 
-Every shipped query has a CLI subcommand under
-`idiolect orchestrator <subcommand>` that calls the same
-endpoint:
+The generated CLI exposes the spec entries that declare a `cli`
+mapping:
 
 ```bash
 idiolect orchestrator bounties
@@ -64,9 +67,9 @@ idiolect orchestrator adapters --framework hasura
 idiolect orchestrator verifications --lens_uri at://...
 ```
 
-The CLI dispatcher (in
-`crates/idiolect-cli/src/generated.rs`) is generated from the
-same spec the HTTP routes are.
+Other HTTP queries have no CLI subcommand. The dispatcher in
+`crates/idiolect-cli/src/generated.rs` is generated from the
+same spec as the HTTP routes.
 
 ## Add a query
 
@@ -78,8 +81,9 @@ document with a top-level `queries` array). To add one:
    panproto-expr expression), and the record kind it iterates
    over.
 2. Run `cargo run -p idiolect-codegen`.
-3. The generated tree picks up the new query: HTTP route,
-   query-string parser, response shape, and CLI subcommand.
+3. The generated tree picks up the HTTP route, XRPC alias,
+   query-string parser, and response shape. Add a `cli` mapping if the
+   query also needs a CLI subcommand.
 
 The hand-written part is the panproto-expr predicate inside the
 spec entry. The generated tree handles routing, parameter
@@ -87,11 +91,9 @@ parsing, and response encoding.
 
 ## Observability
 
-The orchestrator exposes `/metrics` in Prometheus exposition
-format, plus structured `tracing` logs. The exact metric names
-and label sets are defined in
-`crates/idiolect-orchestrator/src/http.rs`. See the source for
-the live list.
+The orchestrator exposes `/metrics` in Prometheus exposition format
+and emits structured `tracing` logs. The metric names and label sets
+are defined in `crates/idiolect-orchestrator/src/http.rs`.
 
 ## Deployment
 

--- a/docs/book/src/guide/publish-lens.md
+++ b/docs/book/src/guide/publish-lens.md
@@ -126,7 +126,7 @@ spawnable request future.
 
 ## Make it discoverable
 
-The 0.11.1 orchestrator catalogs `dev.idiolect.*` records, not
+The 0.12.0 orchestrator catalogs `dev.idiolect.*` records, not
 `dev.panproto.schema.lens` records. Consumers fetch a known lens URI
 directly. Publish idiolect records that point to the lens to make that
 URI discoverable:

--- a/docs/book/src/guide/publish-lens.md
+++ b/docs/book/src/guide/publish-lens.md
@@ -1,12 +1,15 @@
 # Publish and resolve a lens
 
-A lens on the network is two artifacts:
+A [lens](../glossary.md#lens "A bidirectional transformation between data schemas")
+on the network depends on three records:
 
 1. A `dev.panproto.schema.lens` record on a PDS, carrying the
    protolens (or protolens chain) blob and pointers to the source
    and target schemas.
-2. The two schemas themselves, each a `dev.panproto.schema.schema`
-   record (or a `getSchema` xrpc response from a panproto vcs).
+2. Its source schema, as a `dev.panproto.schema.schema` record.
+3. Its target schema, as a `dev.panproto.schema.schema` record. A
+   `getSchema` XRPC response from a panproto VCS may supply either
+   schema instead.
 
 Consumers resolve the lens record by at-uri. The runtime
 instantiates against the two schemas.
@@ -16,18 +19,18 @@ instantiates against the two schemas.
 The shortest path is to derive it from a schema diff:
 
 ```bash
-schema lens generate old.json new.json --protocol atproto > chain.json
+schema lens generate --protocol atproto old.json new.json --save chain.json
 ```
 
 `schema` is the panproto CLI. `chain.json` is a protolens chain in
 panproto's serialized format. See the
-[panproto protolens skill](https://panproto.dev/) for what the chain
+[panproto book](https://panproto.dev/book/) for what the chain
 looks like and how to inspect it.
 
 ## Stage it
 
-```rust
-use idiolect_records::{PanprotoLens, AtUri, Datetime};
+```text
+use idiolect_records::{AtUri, Datetime, PanprotoLens, PanprotoLensRoundTripClass};
 
 let chain: serde_json::Value = serde_json::from_slice(&std::fs::read("chain.json")?)?;
 
@@ -36,7 +39,7 @@ let lens = PanprotoLens {
     created_at: Datetime::parse("2026-04-19T00:00:00.000Z").unwrap(),
     laws_verified: Some(true),
     object_hash: format!("sha256:{}", sha256_hex(&blob_bytes)),
-    round_trip_class: Some("isomorphism".into()),
+    round_trip_class: Some(PanprotoLensRoundTripClass::Iso),
     source_schema: AtUri::parse(
         "at://did:plc:tutorial.dev/dev.panproto.schema.schema/v1",
     )?,
@@ -51,9 +54,9 @@ Three fields warrant care:
 - `object_hash` is a content-addressed identifier for the chain
   bytes. The `VerifyingResolver` will refuse to hand the lens to
   the runtime unless the hash matches the canonical bytes.
-- `round_trip_class` is the optic class panproto's classifier
-  produces (`isomorphism`, `injection`, `projection`, `affine`,
-  `general`). Consumers use this to route review.
+- `round_trip_class` uses the wire values `iso`, `retraction`,
+  `projection`, and `opaque`. Consumers may use the class to select
+  an appropriate review path.
 - `laws_verified` is a soft assertion that the chain passed
   panproto's coercion-law and existence checks. A true value here
   is meaningless without a corresponding `dev.idiolect.verification`
@@ -65,7 +68,7 @@ Three fields warrant care:
 Construct a `SigningPdsWriter` from a reqwest PDS client plus a
 DPoP prover, wrap it in a `RecordPublisher`, and call `create`:
 
-```rust
+```text
 use idiolect_lens::{
     P256DpopProver, RecordPublisher, ReqwestPdsClient, SigningPdsWriter,
 };
@@ -86,18 +89,18 @@ let resp = publisher.create(&lens).await?;
 `pkcs8_pem` is converted from the session's
 `dpop_private_key_jwk` via an external JWK-to-PKCS8 helper.
 Driving the OAuth dance and persisting the session is the
-caller's job. See [Configure OAuth sessions](./oauth.md). The
-PDS rejects the record if the chain blob does not parse, the
-schema at-uris do not resolve, or the canonical bytes do not
-match the declared `object_hash`.
+caller's job. See [Configure OAuth sessions](./oauth.md). A PDS may
+validate the record's lexicon shape, but it does not run idiolect's
+resolver or content-hash checks. Validate the chain and hash before
+publication; consumers should resolve through `VerifyingResolver`.
 
 ## Resolve it
 
 The complement of publishing is resolving. Given an at-uri, the
-[`Resolver`](../reference/crates/idiolect-lens.md#resolver) trait
+[`Resolver`](../reference/crates/idiolect-lens.md#resolvers) trait
 hands back a `PanprotoLens` record:
 
-```rust
+```text
 use idiolect_lens::{
     PdsResolver, ReqwestPdsClient, VerifyingResolver, CachingResolver, Resolver,
 };
@@ -117,17 +120,16 @@ and rejects the record on mismatch. `CachingResolver` keeps the
 result in a TTL'd cache so repeated `apply_lens` calls do not
 re-fetch.
 
-`Arc<dyn Resolver>` is supported (since v0.8.0). The resolver
-futures are `Send`, so handlers in async HTTP frameworks can hold
-the resolver behind a trait object and call `apply_lens` from
-inside an `#[async_trait]` impl.
+`Resolver` is object-safe, and its futures are `Send`. Thus, an async
+service may hold `Arc<dyn Resolver>` and call `apply_lens` from a
+spawnable request future.
 
 ## Make it discoverable
 
-The orchestrator is the catalog the network queries. Once the
-firehose indexer ingests your `dev.panproto.schema.lens` commit,
-the orchestrator's lens query will return it. To make consumers
-prefer your lens over alternatives:
+The 0.11.1 orchestrator catalogs `dev.idiolect.*` records, not
+`dev.panproto.schema.lens` records. Consumers fetch a known lens URI
+directly. Publish idiolect records that point to the lens to make that
+URI discoverable:
 
 - Publish a `dev.idiolect.recommendation` from a community DID
   endorsing the lens path under stated conditions.

--- a/docs/book/src/guide/verify.md
+++ b/docs/book/src/guide/verify.md
@@ -1,15 +1,15 @@
 # Author a verification runner
 
-A verification runner is a function that takes a lens (and a
-small set of typed inputs) and returns a `Verification` record
-with `result` set to `Holds`, `Falsified`, or `Inconclusive`.
+A [verification](../glossary.md#verification "A signed claim that a lens satisfies a stated property")
+runner takes a lens and typed inputs, then returns a `Verification`
+record with `result` set to `Holds`, `Falsified`, or `Inconclusive`.
 The result record is publishable as a
 `dev.idiolect.verification`; downstream consumers reading the
 record can decide whether to trust it.
 
 The runner trait:
 
-```rust
+```text
 pub trait VerificationRunner: Send + Sync {
     fn kind(&self) -> VerificationKind;
     fn tool(&self) -> Tool;
@@ -36,13 +36,12 @@ Four kinds ship in `crates/idiolect-verify/src/`:
 
 The lexicon's `verification.kind` field is open-enum and lists
 additional kinds (`formal-proof`, `conformance-test`,
-`convergence-preserving`). Those kinds are recognised but not
+`convergence-preserving`). Those kinds are recognized but not
 shipped as runners. Communities that need them author their own.
 
 ## Add a runner kind
 
-The project's spec-driven layout means adding a kind is two
-edits:
+Adding a kind requires two source edits and regeneration:
 
 1. Add an entry to `verify-spec/runners.json` declaring the kind
    and its description. Run `cargo run -p idiolect-codegen`.
@@ -53,11 +52,10 @@ edits:
    under `crates/idiolect-verify/src/`. Re-export it from
    `lib.rs`.
 
-The runner's `kind()` returns the new `VerificationKind`
-variant. The `run` method does the work and returns a
-`Verification` record. Use `build_verification` (in
-`runner.rs`) to package the result with the structured
-`property` field.
+The runner's `kind()` returns the new `VerificationKind` variant. Its
+`run` method performs the check and returns a `Verification`. Use
+`idiolect_verify::runner::build_verification` to package the result
+with its structured `property` field.
 
 ## Test
 
@@ -72,7 +70,7 @@ a call to `runner.run(...)`, an assertion on the returned
 Once you have a `Verification`, publish it via
 `idiolect_lens::RecordPublisher`:
 
-```rust
+```text
 use idiolect_lens::RecordPublisher;
 
 let publisher = RecordPublisher::new(writer, my_did);
@@ -80,10 +78,10 @@ let resp = publisher.create(&verification).await?;
 println!("published: {}", resp.uri);
 ```
 
-The publisher serializes the record, splices the `$type` field,
-and forwards to the configured `PdsWriter`. The signing path
-goes through `SigningPdsWriter` plus a `DpopProver` from the
-`pds-reqwest` and (optionally) `dpop-p256` features.
+The publisher serializes the record, inserts `$type`, and forwards it
+to the configured `PdsWriter`. For OAuth-bound writes, combine
+`SigningPdsWriter` with a `DpopProver` from the `pds-reqwest` and
+`dpop-p256` features.
 
 ## CLI surface
 
@@ -91,10 +89,10 @@ The `idiolect verify <kind>` subcommand wraps each shipped
 runner against a live PDS via `PdsResolver` + `PdsSchemaLoader`:
 
 ```text
-idiolect verify roundtrip-test  --lens AT_URI [--corpus PATH]
-idiolect verify property-test   --lens AT_URI  --corpus PATH  [--budget N]
-idiolect verify static-check    --lens AT_URI
-idiolect verify coercion-law    --lens AT_URI  --vcs-url URL  --standard STD
+idiolect verify roundtrip-test  --lens AT_URI [--corpus PATH] [--pds-url URL] [--verifier-did DID]
+idiolect verify property-test   --lens AT_URI --corpus PATH [--budget N] [--pds-url URL] [--verifier-did DID]
+idiolect verify static-check    --lens AT_URI [--pds-url URL] [--verifier-did DID]
+idiolect verify coercion-law    --lens AT_URI --vcs-url URL --standard STD [--version V] [--violation-threshold N] [--verifier-did DID]
 ```
 
 Corpus files may be JSON arrays or JSON Lines. The

--- a/docs/book/src/guide/vocabulary.md
+++ b/docs/book/src/guide/vocabulary.md
@@ -1,10 +1,10 @@
 # Author a community vocabulary
 
-Open-enum slugs across the idiolect lexicons resolve through a
-`dev.idiolect.vocab` record. That record carries a typed
-multi-relation knowledge graph: nodes (concept, relation, instance,
-type, collection) and edges with a relation slug, plus full OWL
-Lite property characteristics and SKOS Core annotations.
+[Open-enum](../glossary.md#open-enum "An enum that preserves unknown string values")
+slugs may point to a `dev.idiolect.vocab` record. The record stores a
+typed graph whose relation nodes may declare
+[OWL 2](https://www.w3.org/TR/owl2-syntax/) property characteristics and whose
+concept nodes may carry SKOS Core fields.
 
 This guide covers the authoring side: writing the JSON, declaring
 relation properties, and publishing the record.
@@ -59,13 +59,12 @@ declared as metadata:
 }
 ```
 
-The shipped properties cover the OWL Lite set: `symmetric`,
+The shipped fields cover these OWL 2 property characteristics: `symmetric`,
 `asymmetric`, `transitive`, `reflexive`, `irreflexive`,
 `functional`, `inverseFunctional`, plus `inverseOf` and a per-
-relation `world` override. The runtime walks the asserted edges
-and validates them against these properties. Contradictions
-(`symmetric+asymmetric`, `reflexive+irreflexive`) produce a
-`PropertyContradiction` violation at publish time.
+relation `world` override. `VocabGraph::validate` walks asserted edges
+and reports violations. `RecordPublisher` does not call this method,
+so run it before publication.
 
 ## Add edges
 
@@ -114,25 +113,28 @@ Collection.
 
 ## Validate
 
-```bash
-schema check vocab.json
+```text
+use idiolect_records::{Vocab, vocab::VocabGraph};
+
+let bytes = std::fs::read("vocab.json")?;
+let vocab: Vocab = serde_json::from_slice(&bytes)?;
+let violations = VocabGraph::from_vocab(&vocab).validate();
+if !violations.is_empty() {
+    anyhow::bail!("vocabulary violations: {violations:#?}");
+}
 ```
 
-The check runs panproto's structural validation plus the OWL Lite
-consistency walker. Violations are listed with the offending edge
-or property.
-
-For programmatic validation, construct a `Vocab` value and call
-`VocabGraph::from_vocab(&vocab).validate()`. Violations are
-returned as a `Vec<VocabViolation>` listing each offending edge
-or property.
+Deserialization checks the generated record shape. `validate()` then
+returns `Vec<VocabViolation>`, with one entry for each graph-property
+failure. Panproto's `schema check` compares schema migrations; it does
+not validate a `dev.idiolect.vocab` record.
 
 ## Publish
 
 Same path as any other record. Construct a writer, wrap it in
 `RecordPublisher`, and call `create`:
 
-```rust
+```text
 use idiolect_lens::{
     P256DpopProver, RecordPublisher, ReqwestPdsClient, SigningPdsWriter,
 };
@@ -154,27 +156,24 @@ let resp = publisher.create(&vocab).await?;
 ```
 
 `pkcs8_pem` is converted from the session's
-`dpop_private_key_jwk` via an external JWK-to-PKCS8 helper. The
-PDS validates the record against the lexicon before commit.
-Malformed values surface as commit errors. Driving the OAuth
-dance and persisting the session is the caller's job. See
-[Configure OAuth sessions](./oauth.md).
+`dpop_private_key_jwk` via an external JWK-to-PKCS8 helper. Request
+PDS-side lexicon validation when the deployment supports it, but keep
+the local typed and graph checks: PDS validation does not run
+`VocabGraph::validate`. See [Configure OAuth sessions](./oauth.md).
 
 ## Use the published vocab
 
-Once the vocab is on the network, any open-enum field whose
-sibling `*Vocab` points at your at-uri resolves slugs through your
-nodes. Consumers reading the record see one of three things:
+Once the vocabulary is on the network, an open-enum field may point to
+it through the sibling `*Vocab` field. Rust consumers see one of two
+enum forms:
 
-- A known slug (matches a node id).
-- An `Other(String)` value (the slug exists in your vocab but the
-  reading consumer is on an older codegen run).
-- An unknown value (the slug does not appear in your vocab and
-  `world` is permissive enough to accept it).
+- A generated known variant when the slug appears in the lexicon's
+  `knownValues` list.
+- `Other(String)` for every other wire slug, whether or not a
+  referenced vocabulary declares it.
 
-The `is_subsumed_by`, `satisfies`, and `translate_to` helpers
-emitted on every open-enum type use the vocab to answer
-slug-relation questions without the consumer manually walking the
-edges. See
+The `is_subsumed_by`, `satisfies`, and `translate_to` helpers query a
+loaded `VocabGraph` or `VocabRegistry`; deserializing the enum does not
+fetch the referenced record. See
 [The vocabulary knowledge graph](../concepts/vocab-graph.md) for
 the semantics.

--- a/docs/book/src/index.md
+++ b/docs/book/src/index.md
@@ -1,51 +1,58 @@
 # idiolect
 
-idiolect is a federated runtime for cross-schema interoperability on
-[ATProto](https://atproto.com). It uses
-[panproto](https://github.com/panproto/panproto) as its schema and lens
-substrate. Records are signed and content-addressed; translations
-between records are lenses with formal `get` / `put` laws; and the
-sociotechnical layer above the lenses (recommendations, beliefs,
-verifications, deliberations) is itself a small set of ATProto
-lexicons (`dev.idiolect.*`).
+idiolect translates a record from one community's schema into another's while
+keeping the translation, its evidence, and its social standing inspectable. It
+runs on [AT Protocol](./glossary.md#at-protocol "The federated protocol that hosts idiolect records and services")
+and uses [Panproto](./glossary.md#panproto "The schema and bidirectional-transformation substrate used by idiolect")
+for schema comparison and lens execution.
 
-The name comes from linguistics:
+The project names its unit of local variation the
+[**idiolect**](./glossary.md#idiolect "One party's schemas, lenses, vocabularies, and conventions").
+A [**dialect**](./glossary.md#dialect "A community's published bundle of preferred schemas, lenses, and deprecations")
+records a community convention, while a
+[**language**](./glossary.md#language "The federated substrate on which idiolects and dialects interact")
+is the substrate on which those local choices meet. None of the three requires a
+central schema registry.
 
-- An **idiolect** is one party's choice of schemas, lenses, and conventions.
-- A **dialect** is the bundle of idiolects a community treats as canonical.
-- A **language** is the federated substrate over which idiolects and
-  dialects meet, disagree, and slowly converge without a central
-  arbiter.
+## Start from your task
 
-If you are new, read [Why idiolect
-exists](./concepts/why-idiolect.md) and then [What you need
-first](./concepts/prerequisites.md). ATProto's model is a deep
-dependency worth learning properly; panproto contributes a single
-concept, the lens. For the underlying theory beyond that, see the
-project [README](https://github.com/idiolect-dev/idiolect#readme)
-and the [deliberation lexicons](./concepts/deliberation.md).
+### Beginner: get a result in about five minutes
 
-## Where to start
+[Install the checked-out CLI and resolve a record](./tutorial/01-install.md), then
+[validate it against its Lexicon](./tutorial/02-validate.md). These first two
+steps produce a concrete resolution and validation result before introducing
+lens laws, network publication, or the project's social records.
 
-The documentation follows the [Diátaxis](https://diataxis.fr/)
-structure:
+### Project integration: connect an existing system
 
-- The [Tutorial](./tutorial/index.md) walks through one example end
-  to end: install, fetch a record, validate, apply a lens, run a
-  verification, publish a recommendation. Read this first if you have
-  not used idiolect before.
-- The [Guides](./guide/index.md) are task-oriented. Each guide
-  answers a question of the form "how do I do X?". Reach for these
-  when you know what you want to accomplish.
-- The [Concepts](./concepts/index.md) explain the underlying model:
-  why the project exists, the idiolect-dialect-language frame, the
-  `dev.idiolect.*` lexicon family, lens semantics, the vocabulary
-  knowledge graph, the observer protocol, and the lexicon-evolution
-  policy. Read these when you want to understand why something is
-  the way it is.
-- The [Reference](./reference/index.md) is the per-symbol detail:
-  one page per crate, one page per lexicon, the CLI surface, the
-  HTTP query API, and the stability policy.
+Choose the guide that matches the work in front of you: [generate Rust and
+TypeScript types](./guide/codegen.md), [publish a
+lens](./guide/publish-lens.md), [index the
+firehose](./guide/index-firehose.md), or [run the query
+API](./guide/orchestrator.md). Each guide links to the exact crate, CLI, or wire
+reference needed during implementation.
+
+### Advanced and formal: extend the model
+
+Begin with [lens semantics and laws](./concepts/lens-laws.md) or the
+[vocabulary knowledge graph](./concepts/vocab-graph.md), then move to the
+[observer protocol](./concepts/observer.md), [Lexicon evolution
+policy](./concepts/lexicon-evolution.md), and [crate extension
+points](./reference/crates/index.md). The [reading-path page](./paths.md) gives a
+longer route through each level.
+
+## How the book is organized
+
+The book keeps the four [Diátaxis](https://diataxis.fr/) functions separate:
+
+- The [tutorial](./tutorial/index.md) teaches through one runnable sequence.
+- The [guides](./guide/index.md) give procedures for particular tasks.
+- The [concepts](./concepts/index.md) explain the mechanisms and their limits.
+- The [reference](./reference/index.md) records exact APIs, fields, and commands.
+
+Use the [glossary](./glossary.md) for short definitions. The paths above cross
+the four sections, but they do not turn a tutorial into reference material or a
+conceptual explanation into a procedure.
 
 ## Architecture
 
@@ -89,14 +96,14 @@ flowchart TB
     LENS --> VER
 ```
 
-Lexicons under `lexicons/dev/idiolect/` are the single source of
-truth. Rust types and TypeScript validators are derived from
-them. Three downstream crates carry a taxonomy of
-similarly-shaped items (the orchestrator's queries, the
-observer's methods, the verifier's runners). Each lives behind a
-declarative JSON spec in `<crate>-spec/`; codegen emits the
-wire-up, including the CLI dispatcher that fronts the
-orchestrator's queries.
+Lexicons under `lexicons/dev/idiolect/` are the source of truth for the record
+family. Code generation derives Rust types and TypeScript validators from those
+files. The orchestrator queries, observer methods, and verifier runners each add
+a declarative JSON specification; code generation emits their dispatch and wire
+integration. This separation is the **declarative boundary (DB)**: record and
+method taxonomies live in data, while runtime code implements their behavior.
+The DB lets reviewers distinguish generated contracts from handwritten runtime
+semantics.
 
 ## Stability
 

--- a/docs/book/src/paths.md
+++ b/docs/book/src/paths.md
@@ -1,0 +1,45 @@
+# Choose a reading path
+
+The book retains four [Diátaxis](https://diataxis.fr/) sections because each
+serves a different kind of work: the tutorial teaches through a sequence, the
+guides give procedures, the concepts explain the model, and the reference pages
+record exact contracts. The paths below cross those sections without merging
+their functions.
+
+## Beginner: resolve and validate a record
+
+Start with [Install the CLI and fetch a lens](./tutorial/01-install.md). It produces
+a concrete result with the checked-out CLI, then points to
+[Validate a typed record](./tutorial/02-validate.md). Continue through the
+tutorial only when you want to apply and verify a lens or publish a
+recommendation.
+
+## Intermediate: integrate a project
+
+Begin with the task closest to your project:
+
+- [Run codegen](./guide/codegen.md) to derive Rust and TypeScript surfaces from
+  a Lexicon family.
+- [Author a community vocabulary](./guide/vocabulary.md) to add governed,
+  machine-readable terms.
+- [Publish and resolve a lens](./guide/publish-lens.md) to put a translation on
+  the network.
+- [Index a firehose](./guide/index-firehose.md) to consume repository events.
+- [Run the orchestrator HTTP API](./guide/orchestrator.md) to query indexed
+  records.
+
+Use the corresponding [crate](./reference/crates/index.md),
+[Lexicon](./reference/lexicons/index.md), [CLI](./reference/cli.md), or
+[HTTP API](./reference/http-api.md) page when implementation work requires an
+exact signature or wire contract.
+
+## Advanced: extend or analyze the system
+
+Read [Lens semantics and laws](./concepts/lens-laws.md) before changing lens
+execution or verification, and read [The vocabulary knowledge
+graph](./concepts/vocab-graph.md) before extending vocabulary inference. The
+[Observer protocol](./concepts/observer.md) and [Lexicon evolution
+policy](./concepts/lexicon-evolution.md) connect those formal objects to runtime
+behavior. Then use the [crate reference](./reference/crates/index.md) to find
+extension traits and the [stability policy](./reference/stability.md) to decide
+which contracts downstream code may rely on.

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -1,7 +1,7 @@
 # CLI
 
 `idiolect` is the command-line tool. The surface below reflects
-idiolect 0.11.1.
+idiolect 0.12.0.
 
 ## Top-level subcommands
 

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -1,6 +1,7 @@
 # CLI
 
-`idiolect` is the command-line tool. The full surface is below.
+`idiolect` is the command-line tool. The surface below reflects
+idiolect 0.11.1.
 
 ## Top-level subcommands
 
@@ -28,7 +29,8 @@ its calls to the orchestrator's HTTP API.
 idiolect resolve <did>
 ```
 
-Resolve a DID via `idiolect-identity::ReqwestIdentityResolver`.
+Resolve a [DID](../glossary.md#did "A decentralized identifier for an AT Protocol identity")
+via `idiolect-identity::ReqwestIdentityResolver`.
 Prints `{ did, method, handle, pds_url, also_known_as }`.
 
 ## `fetch`
@@ -102,7 +104,9 @@ for `<kind>` (which can be either the unqualified kind like
 discriminator, and POSTs `com.atproto.repo.createRecord` using
 the stored session's bearer auth.
 
-When `--did` is omitted the CLI picks the first stored session.
+When `--did` is omitted, the CLI uses the first session returned by
+the filesystem scan; that order is unspecified. Pass `--did` in
+scripts and multi-account environments.
 When `--rkey` is omitted the CLI generates a TID-shaped key.
 
 Prints `{uri, cid}` of the published record on success.
@@ -131,16 +135,17 @@ many cases run.
 ```text
 idiolect encounter record \
   --lens <AT-URI> --source-schema <AT-URI> [--target-schema <AT-URI>] \
-  [--vocab <AT-URI>] [--kind <KIND>] [--visibility <V>] [--text-only]
+  [--action-vocab <AT-URI>] [--kind <KIND>] [--visibility <V>] [--text-only]
 ```
 
-Publishes a `dev.idiolect.encounter` record. The exact flag set
-is in `crates/idiolect-cli/src/encounter.rs`.
+Prints a `dev.idiolect.encounter` body after prompting for a structured
+`use` value. It does not publish the body. Save the JSON and pass it to
+`idiolect publish encounter --record <path>`.
 
 ## Output format
 
-All commands print pretty-printed JSON to stdout on success.
-Errors go to stderr:
+Data commands print pretty-printed JSON to stdout. `version` and
+`help` print text. Errors go to stderr:
 
 ```text
 error: <message>
@@ -148,12 +153,11 @@ error: <message>
 
 Pipe stdout to `jq` for further processing.
 
-## Roadmap
+## Authentication boundary
 
 The shipped login path uses app passwords in legacy Bearer
 mode (`com.atproto.server.createSession` plus
-`Authorization: Bearer <token>`). The full OAuth + DPoP flow
-via `atrium-oauth` (browser handoff, PKCE, DPoP-bound tokens)
-is the next-iteration login UX. The library `OAuthSession`
-shape and `OAuthTokenStore` trait are already in place to
-receive whatever the dance returns.
+`Authorization: Bearer <token>`). Its session file is not an
+`idiolect_oauth::OAuthSession` and contains no DPoP private key.
+Applications that require OAuth with DPoP should use
+`idiolect-oauth` and an OAuth client directly.

--- a/docs/book/src/reference/crates/idiolect-cli.md
+++ b/docs/book/src/reference/crates/idiolect-cli.md
@@ -6,9 +6,8 @@
 > CLI is intended to be installed and run, not depended on as a
 > library.
 
-The `idiolect` command-line tool. Wraps the library crates so
-operators and end users do not need to write Rust for common
-operations.
+The `idiolect` command-line tool wraps the library crates so operators and end
+users do not need to write Rust for common operations.
 
 ```bash
 cargo install --path crates/idiolect-cli
@@ -25,13 +24,16 @@ idiolect resolve <did>
 idiolect fetch <at-uri>
 idiolect orchestrator <subcommand>
 idiolect encounter record [...]
+idiolect oauth <login|list|logout> [...]
+idiolect publish <kind> --record <path> [...]
+idiolect verify <kind> [...]
 idiolect version
 idiolect help
 ```
 
 The full reference is the [CLI reference](../cli.md).
 
-## Why no clap
+## Parser boundary
 
 The CLI uses a hand-rolled subcommand parser. Two reasons:
 
@@ -50,9 +52,9 @@ The CLI's `orchestrator …` dispatcher is emitted from
 the dispatcher. The new subcommand becomes available
 automatically.
 
-The hand-written subcommands (`resolve`, `fetch`,
-`encounter record`, `version`, `help`) live in `main.rs` and
-`encounter.rs`.
+The hand-written subcommands (`resolve`, `fetch`, `encounter record`,
+`oauth`, `publish`, `verify`, `version`, and `help`) live in
+`main.rs` and their sibling modules.
 
 ## Output
 
@@ -64,6 +66,8 @@ Errors go to stderr with `error: <message>`.
 | Setting | Default | Override |
 | --- | --- | --- |
 | Orchestrator URL | `http://localhost:8787` | `--url` flag on `orchestrator` subcommands |
-| Log level | `info` | `RUST_LOG` env var |
+| Log level | `warn` | `RUST_LOG` environment variable |
+| Session directory | `$HOME/.config/idiolect/sessions` | `IDIOLECT_SESSION_DIR` environment variable |
+| Login app password | none | `--app-password`, `ATPROTO_APP_PASSWORD`, or `ATPROTO_PASSWORD` |
 
 The CLI does not read a config file.

--- a/docs/book/src/reference/crates/idiolect-codegen.md
+++ b/docs/book/src/reference/crates/idiolect-codegen.md
@@ -6,32 +6,39 @@
 > machinery, not a library you depend on. There is no docs.rs
 > page. The authoritative reference is the source above.
 
-Lexicon-driven Rust + TypeScript emitter. Reads
+`idiolect-codegen` is a Rust and TypeScript emitter driven by the project
+[lexicons](../../glossary.md#lexicon). It reads
 `lexicons/dev/idiolect/*.json` and the three spec files
 (`orchestrator-spec/queries.json`, `observer-spec/methods.json`,
-`verify-spec/runners.json`). Writes the generated modules under
-each downstream crate.
+`verify-spec/runners.json`), then writes the generated modules under each
+downstream crate.
 
 The crate is shipped both as a library (callable from a
 downstream emitter) and as a binary (`cargo run -p idiolect-codegen`).
 
 ## Binary subcommands
 
-`cargo run -p idiolect-codegen` invokes the binary. The two
-operations:
+`cargo run -p idiolect-codegen` invokes the binary. The accepted
+subcommands are:
 
-| Mode | Purpose |
+| Subcommand | Purpose |
 | --- | --- |
-| Default | Emit every generated tree. |
-| `--check` | Verify the working tree matches what the default mode would produce. Exits non-zero on drift. |
+| `generate` (default) | Emit every generated tree. |
+| `check` | Verify that the working tree matches generated output; exit nonzero on drift. The legacy `--check` spelling is also accepted. |
+| `example <nsid>` | Print a bundled fixture. A record kind such as `encounter` may replace the full NSID. |
+| `list` | List lexicons, their kinds, and fixture availability. |
+| `doctor` | Check the workspace layout and fixtures. |
+| `check-compat --baseline <path>` | Classify changes against a baseline lexicon tree; exit `1` if a breaking change is found. |
+| `help` | Print command help. |
 
-The check mode is the drift gate. CI runs it on every PR.
+The check mode compares generated output with the checked-in tree. CI runs it
+on every PR.
 
 ## Library API
 
 The callable surface is in `idiolect_codegen::emit`:
 
-```rust
+```text
 use idiolect_codegen::emit::{emit_rust, emit_typescript};
 use idiolect_codegen::emit::family::{FamilyConfig, idiolect_family};
 use idiolect_codegen::lexicon::LexiconDoc;
@@ -40,10 +47,10 @@ use idiolect_codegen::Example;
 
 `emit_rust(docs, examples, family)` and
 `emit_typescript(docs, examples, family)` take pre-loaded
-`LexiconDoc` and `Example` slices plus a `FamilyConfig`, and
-return `Vec<EmittedFile>`. Loading the lexicons from disk is the
-caller's job. The workspace binary does this through the
-`idiolect_codegen::lexicon` parser.
+`LexiconDoc` and `Example` slices plus a `&FamilyConfig`, and
+return `anyhow::Result<Vec<EmittedFile>>`. Loading lexicons from
+disk is the caller's job. The workspace binary parses every
+document through both its internal parser and panproto 0.70.1.
 
 `FamilyConfig` carries three `Cow<'static, str>` fields: the
 marker name, the family ID, and the NSID prefix. The shipped
@@ -79,9 +86,9 @@ Each spec file is a single JSON document with a top-level
 dispatch tables and typed enums. The hand-written predicates
 live alongside the generated tree.
 
-## Drift gate semantics
+## Generated-drift check semantics
 
-`cargo run -p idiolect-codegen -- --check` runs the same emitter
+`cargo run -p idiolect-codegen -- check` runs the same emitter
 as the default mode, then byte-compares each emitted file
 against the working-tree counterpart. Any diff is a drift error,
 with a per-file diff. Run `cargo run -p idiolect-codegen` to
@@ -91,7 +98,7 @@ fix.
 
 Three rules:
 
-1. NSIDs are ASCII, lowercase, dot-separated. The emitter
+1. [NSIDs](../../glossary.md#nsid) are ASCII, lowercase, dot-separated. The emitter
    rejects non-conforming input.
 2. PascalCase names are derived deterministically from a slug.
    On collision (`foo-bar` and `foo_bar`), the second occurrence

--- a/docs/book/src/reference/crates/idiolect-codegen.md
+++ b/docs/book/src/reference/crates/idiolect-codegen.md
@@ -50,7 +50,7 @@ use idiolect_codegen::Example;
 `LexiconDoc` and `Example` slices plus a `&FamilyConfig`, and
 return `anyhow::Result<Vec<EmittedFile>>`. Loading lexicons from
 disk is the caller's job. The workspace binary parses every
-document through both its internal parser and panproto 0.70.1.
+document through both its internal parser and panproto 0.71.0.
 
 `FamilyConfig` carries three `Cow<'static, str>` fields: the
 marker name, the family ID, and the NSID prefix. The shipped

--- a/docs/book/src/reference/crates/idiolect-identity.md
+++ b/docs/book/src/reference/crates/idiolect-identity.md
@@ -15,7 +15,7 @@ methods, and any additional fields the source document carries.
 
 ```toml
 [dependencies]
-idiolect-identity = { version = "0.11.1", features = ["resolver-reqwest"] }
+idiolect-identity = { version = "0.12.0", features = ["resolver-reqwest"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-identity.md
+++ b/docs/book/src/reference/crates/idiolect-identity.md
@@ -8,13 +8,14 @@
 > (every public type, trait, function, and feature flag) is the
 > docs.rs link above. That is the authoritative reference.
 
-DID resolution. Maps a `did` to a structured `DidDocument`
+The crate resolves a decentralized identifier
+([DID](../../glossary.md#did)) to a structured `DidDocument`
 carrying the also-known-as set, service entries, verification
 methods, and any additional fields the source document carries.
 
 ```toml
 [dependencies]
-idiolect-identity = { version = "0.8", features = ["resolver-reqwest"] }
+idiolect-identity = { version = "0.11.1", features = ["resolver-reqwest"] }
 ```
 
 ## Public surface
@@ -47,6 +48,6 @@ unsupported DID methods.
 ## Caching
 
 The shipped `CachingIdentityResolver` wraps any inner resolver
-with a TTL'd cache. Default TTL and overrides are documented on
-docs.rs. Cache hits skip the HTTP request entirely. Cache misses
-fall through to the inner resolver. Errors are not cached.
+with the `Duration` supplied to `CachingIdentityResolver::new`.
+Cache hits skip the HTTP request entirely. Cache misses fall
+through to the inner resolver. Errors are not cached.

--- a/docs/book/src/reference/crates/idiolect-indexer.md
+++ b/docs/book/src/reference/crates/idiolect-indexer.md
@@ -8,21 +8,21 @@
 > (every public type, trait, function, and feature flag) is the
 > docs.rs link above. That is the authoritative reference.
 
-Firehose consumer factored into three trait surfaces. The crate
+The crate factors a [firehose](../../glossary.md#firehose) consumer
+into three trait surfaces. It
 owns the loop. You bring the stream, the handler, and the cursor
 store.
 
 ```toml
 [dependencies]
-idiolect-indexer = { version = "0.8",
-    features = ["firehose-jetstream", "cursor-filesystem", "reconnecting"] }
+idiolect-indexer = { version = "0.11.1", features = ["firehose-jetstream", "cursor-filesystem", "reconnecting"] }
 ```
 
 ## Public surface
 
 ### Trait surface
 
-```rust
+```text
 pub trait EventStream: Send + Sync {
     async fn next_event(&mut self) -> Result<Option<RawEvent>, IndexerError>;
 }
@@ -44,7 +44,7 @@ delete), CID, and the typed record body (`Option<F::AnyRecord>`).
 
 ### Composer
 
-```rust
+```text
 pub async fn drive_indexer<F, S, H, C>(
     stream: &mut S,
     handler: &H,
@@ -67,9 +67,9 @@ where
 | --- | --- | --- |
 | `JetstreamEventStream` | `firehose-jetstream` | Subscribes to a Jetstream websocket feed. |
 | `TappedEventStream` | `firehose-tapped` | Subscribes to the at-proto-native firehose via `tapped`. |
-| `ReconnectingEventStream<S>` | `reconnecting` | Wraps any `S: EventStream` with exponential-backoff reconnect. |
+| `ReconnectingEventStream<C, F, S>` | `reconnecting` | Recreates an `S: EventStream` with a caller-supplied async connection factory and exponential backoff. |
 | `InMemoryCursorStore` | (always) | `HashMap`-backed; for tests. |
-| `FilesystemCursorStore` | `cursor-filesystem` | One JSON file per stream. |
+| `FilesystemCursorStore` | `cursor-filesystem` | One JSON file containing the cursor map for every subscription ID. |
 | `SqliteCursorStore` | `cursor-sqlite` | One row per stream. Pairs with handlers that also write SQLite. |
 | `NoopRecordHandler` | (always) | Counts events and drops them. Useful as a baseline. |
 | `RetryingHandler` / `CircuitBreakerHandler` | `resilience` | Wraps an inner handler with retry / circuit-breaker policies. |
@@ -86,7 +86,7 @@ boundaries. Variants:
 | `Decode(DecodeError)` | A known NSID failed to decode into its typed record. |
 | `Handler(String)` | Handler returned a handler-defined error. |
 | `MissingBody(String)` | The firehose event had no record body or the body was malformed. |
-| `FamilyContract(String)` | `contains` accepted an NSID but `decode` returned `None` — a family-implementation bug. |
+| `FamilyContract(String)` | `contains` accepted an NSID but `decode` returned `None`; this is a family-implementation bug. |
 
 ## Feature flags
 
@@ -103,6 +103,9 @@ boundaries. Variants:
 
 `drive_indexer` commits the cursor only after the handler
 returns `Ok`. A failing handler does not commit. The loop
-either retries on the next event (default) or surfaces the
-error. For exactly-once semantics, the handler coordinates the
-cursor commit with its own storage transaction.
+returns the error to its caller. Handler retries require the
+`RetryingHandler` wrapper or an application-level policy. The
+shipped driver is thus at-least-once: an event may be handled
+again if the cursor commit fails. A custom driver can coordinate
+its data write and cursor update in one storage transaction when
+both use the same backend.

--- a/docs/book/src/reference/crates/idiolect-indexer.md
+++ b/docs/book/src/reference/crates/idiolect-indexer.md
@@ -15,7 +15,7 @@ store.
 
 ```toml
 [dependencies]
-idiolect-indexer = { version = "0.11.1", features = ["firehose-jetstream", "cursor-filesystem", "reconnecting"] }
+idiolect-indexer = { version = "0.12.0", features = ["firehose-jetstream", "cursor-filesystem", "reconnecting"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-lens.md
+++ b/docs/book/src/reference/crates/idiolect-lens.md
@@ -16,7 +16,7 @@ registry version:
 
 ```toml
 [dependencies]
-idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["pds-reqwest"] }
+idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["pds-reqwest"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-lens.md
+++ b/docs/book/src/reference/crates/idiolect-lens.md
@@ -6,8 +6,9 @@
 > authoritative reference is the source above plus the rustdoc
 > built locally with `cargo doc -p idiolect-lens --open`.
 
-Resolve `dev.panproto.schema.lens` records and run `apply_lens`.
-Bridges idiolect's record runtime to panproto's lens runtime.
+Resolve `dev.panproto.schema.lens` [records](../../glossary.md#record)
+and run `apply_lens`. The crate connects idiolect's record runtime to
+panproto 0.70.1's lens runtime.
 
 Because the crate is `publish = false`, downstream consumers
 depend on it via a git or path reference rather than a
@@ -15,7 +16,7 @@ registry version:
 
 ```toml
 [dependencies]
-idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0", features = ["pds-reqwest"] }
+idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["pds-reqwest"] }
 ```
 
 ## Public surface
@@ -23,8 +24,7 @@ idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.
 ### Resolvers
 
 `Resolver` is the trait every resolver implements. It is
-object-safe (`Arc<dyn Resolver>`) since v0.8.0. The resolve
-future is `Send`.
+object-safe (`Arc<dyn Resolver>`), and its resolve future is `Send`.
 
 Shipped implementations:
 
@@ -50,8 +50,12 @@ The runtime shipped under `idiolect_lens::runtime`:
 - `apply_lens` / `apply_lens_put` — state-based forward / backward.
 - `apply_lens_get_edit` / `apply_lens_put_edit` — edit-based
   variants for incremental translation.
-- `apply_lens_symmetric` — symmetric pairing of two state-based
-  lenses sharing a middle schema.
+- `apply_lens_symmetric` pairs two state-based lenses that share a
+  middle schema. This view-only helper calls panproto 0.70.1's
+  `put_without_complement`, so the incoming span leg must be an
+  isomorphism. A lossy incoming leg requires complement state from an
+  earlier `get` and direct use of panproto's lower-level
+  `SymmetricLens` API.
 
 Each takes a resolver, a schema loader, a `Protocol`, and a
 typed input struct. Each returns a typed output struct. The
@@ -67,7 +71,7 @@ traits over xrpc. Behind feature flags:
 | --- | --- |
 | `pds-reqwest` | `ReqwestPdsClient` (read-only). The reqwest-backed write surface uses `SigningPdsWriter` plus a `DpopProver` (one of `StaticDpopProver`, `NoOpDpopProver`, or `P256DpopProver` with the `dpop-p256` feature). |
 | `pds-atrium` | `AtriumPdsClient`. |
-| `pds-resolve` | `fetcher_for_did`, `publisher_for_did` — DID-to-PDS resolution helpers. Pulls in `idiolect-identity`. |
+| `pds-resolve` | `fetcher_for_did`, `publisher_for_did`; [DID](../../glossary.md#did)-to-[PDS](../../glossary.md#pds) resolution helpers. Pulls in `idiolect-identity`. |
 | `dpop-p256` | The `P256DpopProver` for OAuth-bound DPoP requests. |
 
 ### Generic publisher
@@ -91,7 +95,7 @@ types.
 
 The recommended runtime stack:
 
-```rust
+```text
 use std::sync::Arc;
 use std::time::Duration;
 use idiolect_lens::*;
@@ -106,6 +110,6 @@ let loader = FilesystemSchemaLoader::new("./schema-cache")?;
 let out = apply_lens(&resolver, &loader, &Protocol::default(), input).await?;
 ```
 
-The `Arc<dyn Resolver>` indirection lets a downstream
-orchestrator inject a different resolver (e.g. a record-of-record
-mock for tests) without changing the surface.
+The `Arc<dyn Resolver>` indirection lets a downstream application
+inject a different resolver, such as an in-memory resolver for tests,
+without changing the surrounding API.

--- a/docs/book/src/reference/crates/idiolect-lens.md
+++ b/docs/book/src/reference/crates/idiolect-lens.md
@@ -8,7 +8,7 @@
 
 Resolve `dev.panproto.schema.lens` [records](../../glossary.md#record)
 and run `apply_lens`. The crate connects idiolect's record runtime to
-panproto 0.70.1's lens runtime.
+panproto 0.71.0's lens runtime.
 
 Because the crate is `publish = false`, downstream consumers
 depend on it via a git or path reference rather than a
@@ -51,7 +51,7 @@ The runtime shipped under `idiolect_lens::runtime`:
 - `apply_lens_get_edit` / `apply_lens_put_edit` — edit-based
   variants for incremental translation.
 - `apply_lens_symmetric` pairs two state-based lenses that share a
-  middle schema. This view-only helper calls panproto 0.70.1's
+  middle schema. This view-only helper calls panproto 0.71.0's
   `put_without_complement`, so the incoming span leg must be an
   isomorphism. A lossy incoming leg requires complement state from an
   earlier `get` and direct use of panproto's lower-level

--- a/docs/book/src/reference/crates/idiolect-migrate.md
+++ b/docs/book/src/reference/crates/idiolect-migrate.md
@@ -7,7 +7,7 @@
 > built locally with `cargo doc -p idiolect-migrate --open`.
 
 The crate combines schema-diff classification with
-[lens](../../glossary.md#lens)-based record migration. It is a typed facade over panproto 0.70.1's
+[lens](../../glossary.md#lens)-based record migration. It is a typed facade over panproto 0.71.0's
 `panproto-check` crate and `idiolect-lens`.
 
 Because the crate is `publish = false`, depend via git or path:
@@ -44,8 +44,11 @@ The crate exposes:
 | Diff | Behavior |
 | --- | --- |
 | Non-breaking (added optional, added vertex, added edge) | `classify` returns `compatible = true`; no plan is needed. |
-| Auto-derivable breaking | `plan_auto` returns a `MigrationPlan` with a protolens-chain body and an alignment-quality score. The exact supported shapes follow panproto 0.70.1's `auto_generate`. |
+| Auto-derivable breaking | `plan_auto` returns a `MigrationPlan` with a protolens-chain body and an alignment-quality score. The exact supported shapes follow panproto 0.71.0's `auto_generate`. |
 | Non-auto breaking (removed required, changed required type, added required without default) | `plan_auto` returns `NotAutoDerivable`. The caller writes the lens by hand. |
+
+The alignment-quality score ranks alternatives for one source schema. Panproto
+0.71.0 does not give it a pair-independent confidence interpretation.
 
 ## Dependency boundary
 

--- a/docs/book/src/reference/crates/idiolect-migrate.md
+++ b/docs/book/src/reference/crates/idiolect-migrate.md
@@ -6,33 +6,33 @@
 > authoritative reference is the source above plus the rustdoc
 > built locally with `cargo doc -p idiolect-migrate --open`.
 
-Schema-diff classification plus lens-based record migration.
-Thin typed façade over `panproto-check` (for diff classification)
-and `idiolect-lens` (for record translation).
+The crate combines schema-diff classification with
+[lens](../../glossary.md#lens)-based record migration. It is a typed facade over panproto 0.70.1's
+`panproto-check` crate and `idiolect-lens`.
 
 Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-migrate = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0" }
+idiolect-migrate = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1" }
 ```
 
 ## Public surface
 
 The crate exposes:
 
-- `classify(src, tgt)` — runs the panproto diff and returns a
+- `classify(old, new, protocol)` runs the panproto diff and returns a
   `CompatReport` distinguishing compatible from breaking
   changes.
-- `plan_auto(src, tgt, hints)` — for breaking diffs that are
-  covered by shipped migration recipes, returns a
+- `plan_auto(old, new, protocol, source_schema_hash,
+  target_schema_hash)` asks panproto's `auto_generate` to derive a
   `MigrationPlan` carrying source / target schema hashes plus a
-  lens body the caller can publish. For breaking diffs that
-  resist automation, returns
+  protolens chain the caller can publish. For breaking diffs that
+  resist automatic derivation, it returns
   `Err(PlannerError::NotAutoDerivable)` listing the offending
   changes.
-- `migrate_record(lens, source_record, schema_loader)` — wraps
-  `idiolect_lens::apply_lens` for the one-shot case.
+- `migrate_record(resolver, schema_loader, protocol, lens_uri,
+  source_record)` wraps `idiolect_lens::apply_lens` for one record.
 - `MigrationPlan` — the typed plan struct.
 - `MigrateError`, `MigrateResult`, `PlannerError` — the error
   types.
@@ -44,10 +44,10 @@ The crate exposes:
 | Diff | Behavior |
 | --- | --- |
 | Non-breaking (added optional, added vertex, added edge) | `classify` returns `compatible = true`; no plan is needed. |
-| Auto-derivable breaking (removed optional, renamed vertex via hint) | `plan_auto` returns a `MigrationPlan` with a protolens-chain body. |
+| Auto-derivable breaking | `plan_auto` returns a `MigrationPlan` with a protolens-chain body and an alignment-quality score. The exact supported shapes follow panproto 0.70.1's `auto_generate`. |
 | Non-auto breaking (removed required, changed required type, added required without default) | `plan_auto` returns `NotAutoDerivable`. The caller writes the lens by hand. |
 
-## Why this is a separate crate from idiolect-lens
+## Dependency boundary
 
 Two reasons:
 
@@ -55,8 +55,9 @@ Two reasons:
    is a different shape than the runtime API
    (`apply_lens` plus resolvers).
 2. `idiolect-migrate` depends on `panproto-check`, which is a
-   heavier dep than the lens runtime itself. Keeping it
-   separate keeps the runtime crate's compile-time small.
+   heavier dependency than the lens runtime itself. Separating it
+   avoids adding that dependency to applications that only apply
+   existing lenses.
 
 ## The `idiolect-migrate` binary
 
@@ -74,6 +75,6 @@ for the batch-migration flow.
 
 ## Scope
 
-The crate is a thin façade with no runtime state. The
+The crate is a thin facade with no runtime state. The
 runtime cost of a migration equals the cost of one `apply_lens`
 per record.

--- a/docs/book/src/reference/crates/idiolect-migrate.md
+++ b/docs/book/src/reference/crates/idiolect-migrate.md
@@ -14,7 +14,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-migrate = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1" }
+idiolect-migrate = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0" }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-oauth.md
+++ b/docs/book/src/reference/crates/idiolect-oauth.md
@@ -15,7 +15,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["store-filesystem"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["store-filesystem"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-oauth.md
+++ b/docs/book/src/reference/crates/idiolect-oauth.md
@@ -6,8 +6,8 @@
 > authoritative reference is the source above plus the rustdoc
 > built locally with `cargo doc -p idiolect-oauth --open`.
 
-ATProto OAuth session storage. The crate carries the token-store
-trait and shipped implementations. The OAuth dance itself lives
+The crate provides AT Protocol [OAuth](../../glossary.md#oauth) session storage through its
+token-store trait and shipped implementations. The OAuth dance itself lives
 in `atrium-oauth-client`, and the DPoP signer lives in
 `idiolect-lens` under the `dpop-p256` feature.
 
@@ -15,7 +15,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0", features = ["store-filesystem"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["store-filesystem"] }
 ```
 
 ## Public surface
@@ -44,8 +44,9 @@ returns the live session.
 | `FilesystemOAuthTokenStore` | `store-filesystem` | One JSON file per session. |
 | `SqliteOAuthTokenStore` | `store-sqlite` | One row per session. |
 
-All three implement `OAuthTokenStore`. Anything that takes
-`Arc<dyn OAuthTokenStore>` accepts any of them.
+All three implement `OAuthTokenStore`. The trait uses native async
+methods and is not object-safe. Callers thus parameterize their
+application over a store type or define an object-safe adapter.
 
 ## Errors
 
@@ -62,10 +63,13 @@ build their own at the application boundary.
 
 ## DPoP keys
 
-The session carries a DPoP keypair. Persistence is the store's
+The session carries a Demonstrating Proof of Possession
+([DPoP](../../glossary.md#dpop)) private key as a JWK. Persistence is the store's
 responsibility; both shipped stores persist it alongside the
 session. A custom store must do the same. The OAuth RFC
-requires DPoP keys to survive across requests.
+does not define this key; [RFC 9449](https://www.rfc-editor.org/rfc/rfc9449.html)
+defines DPoP key binding. Reusing the bound key is necessary for
+requests made with the same DPoP-bound token.
 
 The signer behind the DPoP-bound HTTP layer is `P256DpopProver`
 in `idiolect-lens` under the `dpop-p256` feature. The lens

--- a/docs/book/src/reference/crates/idiolect-observer.md
+++ b/docs/book/src/reference/crates/idiolect-observer.md
@@ -14,7 +14,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-observer = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["daemon"] }
+idiolect-observer = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["daemon"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-observer.md
+++ b/docs/book/src/reference/crates/idiolect-observer.md
@@ -6,20 +6,20 @@
 > authoritative reference is the source above plus the rustdoc
 > built locally with `cargo doc -p idiolect-observer --open`.
 
-Fold encounter-family records into observation records. Driven
-by the declarative spec at `observer-spec/methods.json`. Codegen
-emits the method-descriptor table.
+The crate folds encounter-family [records](../../glossary.md#record-family) into observation
+records. The declarative spec at `observer-spec/methods.json` drives the
+surface, and code generation emits the method-descriptor table.
 
 Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-observer = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0", features = ["daemon"] }
+idiolect-observer = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["daemon"] }
 ```
 
 ## Public surface
 
-```rust
+```text
 pub trait ObservationMethod: Send + Sync {
     fn name(&self) -> &str;
     fn version(&self) -> &str;
@@ -84,6 +84,7 @@ implementations:
 | --- | --- |
 | `InMemoryPublisher` | `Vec<Observation>`. For tests. |
 | `PdsPublisher` | Writes via an `idiolect_lens::PdsWriter` to the observer's PDS. |
+| `LogPublisher` | Emits each observation as a structured tracing event. |
 
 ## Errors
 

--- a/docs/book/src/reference/crates/idiolect-orchestrator.md
+++ b/docs/book/src/reference/crates/idiolect-orchestrator.md
@@ -15,7 +15,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-orchestrator = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["daemon", "catalog-sqlite", "query-http"] }
+idiolect-orchestrator = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["daemon", "catalog-sqlite", "query-http"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-orchestrator.md
+++ b/docs/book/src/reference/crates/idiolect-orchestrator.md
@@ -6,15 +6,16 @@
 > authoritative reference is the source above plus the rustdoc
 > built locally with `cargo doc -p idiolect-orchestrator --features daemon --open`.
 
-Read-only HTTP query API over a record catalog. Driven by
-`orchestrator-spec/queries.json`. Codegen emits the routes plus
-the matching CLI dispatcher.
+The crate exposes a read-only HTTP query API over a record
+[catalog](../../glossary.md#catalog). `orchestrator-spec/queries.json` drives
+the surface, and code generation emits both the routes and the matching CLI
+dispatcher.
 
 Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-orchestrator = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0", features = ["daemon", "catalog-sqlite", "query-http"] }
+idiolect-orchestrator = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1", features = ["daemon", "catalog-sqlite", "query-http"] }
 ```
 
 ## Public surface
@@ -54,6 +55,7 @@ Every handler under the `v1` prefix is generated from
 | `GET /v1/recommendations` | Recommendations starting from a given source schema. |
 | `GET /v1/verifications?lens_uri=...` | Verifications for a specific lens. |
 | `GET /v1/verifications/by-kind?...` | Verifications by kind. |
+| `GET /v1/verifications/sufficient?lens_uri=...&kinds=...` | Whether each comma-separated verification kind has at least one `holds` record for the lens. |
 | `GET /v1/communities?...` | Communities for a member DID. |
 | `GET /v1/communities/by-name?...` | Communities by name. |
 | `GET /v1/dialects/for-community?...` | Dialects owned by a community. |
@@ -62,7 +64,8 @@ Every handler under the `v1` prefix is generated from
 | `GET /v1/vocabularies/by-world?...` | Vocabularies declared with a given `world`. |
 | `GET /v1/vocabularies/by-name?...` | Vocabularies by name. |
 
-The full path-and-flag table for each endpoint is generated. See
+Each generated route is also mounted at its `/xrpc/<query-nsid>`
+alias. The full path-and-flag table for each endpoint is generated. See
 [`orchestrator-spec/queries.json`](https://github.com/idiolect-dev/idiolect/blob/main/orchestrator-spec/queries.json)
 for the authoritative list.
 
@@ -81,8 +84,7 @@ for the authoritative list.
 
 ## Observability
 
-`/metrics` exposes Prometheus counters and histograms for the
-catalog and per-endpoint latency. Structured `tracing` logs run
-at `info` level for accepted requests and `debug` for query
-internals. The exact metric names are defined in
-`crates/idiolect-orchestrator/src/http.rs`.
+`/metrics` exposes the readiness gauge, per-kind catalog gauges, and
+the total catalog gauge in Prometheus text format. The daemon emits
+structured lifecycle and failure logs through `tracing`. The exact
+metric names are defined in `crates/idiolect-orchestrator/src/http.rs`.

--- a/docs/book/src/reference/crates/idiolect-records.md
+++ b/docs/book/src/reference/crates/idiolect-records.md
@@ -16,7 +16,7 @@ hand.
 
 ```toml
 [dependencies]
-idiolect-records = "0.11.1"
+idiolect-records = "0.12.0"
 ```
 
 The crate has no transport dependencies; it contains data types and their

--- a/docs/book/src/reference/crates/idiolect-records.md
+++ b/docs/book/src/reference/crates/idiolect-records.md
@@ -8,17 +8,19 @@
 > (every public type, trait, function, and feature flag) is the
 > docs.rs link above. That is the authoritative reference.
 
-Serde record types mirroring the `dev.idiolect.*` lexicons. The
+The crate provides Serde record types that mirror the `dev.idiolect.*`
+[lexicons](../../glossary.md#lexicon "A schema document in the AT Protocol Lexicon language"). The
 contents of `crates/idiolect-records/src/generated/` are written
 by [`idiolect-codegen`](./idiolect-codegen.md). Do not edit by
 hand.
 
 ```toml
 [dependencies]
-idiolect-records = "0.8"
+idiolect-records = "0.11.1"
 ```
 
-No transport dependencies. Pure data.
+The crate has no transport dependencies; it contains data types and their
+validation and dispatch helpers.
 
 ## Public types
 
@@ -49,9 +51,10 @@ not variants of `AnyRecord` (which is scoped to
 
 ### Family
 
-`RecordFamily` is the trait every family implements. The crate
+[`RecordFamily`](../../glossary.md#record-family "A typed set of record NSIDs with a shared decoder")
+is the trait every family implements. The crate
 ships `IdiolectFamily` for `dev.idiolect.*` and the
-`OrFamily<F1, F2>` composer that recognises every NSID either
+`OrFamily<F1, F2>` composer that recognizes every NSID either
 side claims. `detect_or_family_overlap` audits a probe set at
 boot so a configuration mistake does not silently shadow the
 right-side family.
@@ -74,7 +77,7 @@ uniform.
 
 ### Vocab graph helpers
 
-`VocabGraph` is a normalised read-only view over a `Vocab`
+`VocabGraph` is a normalized read-only view over a `Vocab`
 record (graph form, lifted from the legacy tree where present).
 `VocabRegistry` caches multiple graphs by AT-URI for
 cross-vocabulary work. The shipped query verbs
@@ -86,7 +89,7 @@ plus the `validate` walker are documented on docs.rs and in
 ## Examples module
 
 `idiolect_records::examples::*` exports a fixture per record
-kind. Each fixture is the deserialised result of the JSON
+kind. Each fixture is the deserialized result of the JSON
 constant under `lexicons/dev/idiolect/examples/<name>.json`. The
 shipped fixtures cover: `adapter`, `belief`, `bounty`,
 `community`, `correction`, `dialect`, `encounter`,
@@ -106,9 +109,9 @@ dependencies.
 
 ## Errors
 
-Decode failures surface as `serde_json::Error` with a
-`serde_path_to_error`-shaped path. The structured error type for
-the family-decode path is `DecodeError` (re-exported as
-`idiolect_records::DecodeError`). It distinguishes unknown
-NSIDs, decode failures, and family-contract violations (where a
-family's `contains` returned true but `decode` returned `None`).
+The family-decode path returns `DecodeError`, re-exported as
+`idiolect_records::DecodeError`. `UnknownNsid(String)` reports an
+NSID outside the generated family; `Serde(serde_json::Error)` reports
+a typed deserialization failure. The indexer's separate
+`IndexerError::FamilyContract` variant detects disagreement between a
+family's `contains` and `decode` methods.

--- a/docs/book/src/reference/crates/idiolect-verify.md
+++ b/docs/book/src/reference/crates/idiolect-verify.md
@@ -14,7 +14,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1" }
+idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0" }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-verify.md
+++ b/docs/book/src/reference/crates/idiolect-verify.md
@@ -6,19 +6,20 @@
 > authoritative reference is the source above plus the rustdoc
 > built locally with `cargo doc -p idiolect-verify --open`.
 
-Verification runners with declarative dispatch. Driven by
-`verify-spec/runners.json`. Codegen emits the kind taxonomy.
+The crate provides [verification](../../glossary.md#verification) runners with
+declarative dispatch. `verify-spec/runners.json` drives the surface, and code
+generation emits the kind taxonomy.
 
 Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.8.0" }
+idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.11.1" }
 ```
 
 ## Public surface
 
-```rust
+```text
 pub trait VerificationRunner: Send + Sync {
     fn kind(&self) -> VerificationKind;
     fn tool(&self) -> Tool;
@@ -32,7 +33,7 @@ an error: a falsified verification is a first-class record.
 `VerifyError` is reserved for input-shape, transport, or
 irrecoverable-state failures.
 
-The `build_verification` helper packages a runner result into a
+The `runner::build_verification` helper packages a runner result into a
 `Verification` record shaped for direct publication via
 `idiolect_lens::RecordPublisher::create`.
 
@@ -45,12 +46,12 @@ kinds:
 | --- | --- |
 | `roundtrip-test` | `RoundtripTestRunner` — runs `put(get(a)) == a` over a corpus. |
 | `property-test` | `PropertyTestRunner` — runs an arbitrary boolean predicate over a corpus. |
-| `static-check` | `StaticCheckRunner` — runs panproto's existence and structural checks against the lens chain. |
+| `static-check` | `StaticCheckRunner` — resolves the lens's source and target schemas and runs panproto's schema validator on both. |
 | `coercion-law` | `CoercionLawRunner` — runs panproto's sample-based coercion-law checker, optionally via a `CoercionLawClient`. |
 
 The lexicon's `verification.kind` field is open-enum and lists
 additional kinds (`formal-proof`, `conformance-test`,
-`convergence-preserving`). Those kinds are *recognised* but not
+`convergence-preserving`). Those kinds are *recognized* but not
 shipped as runners. Communities that need them author their own
 runner against the trait.
 

--- a/docs/book/src/reference/crates/index.md
+++ b/docs/book/src/reference/crates/index.md
@@ -1,12 +1,12 @@
 # Crates
 
-The workspace ships eleven crates. Each is independently
-versioned but bumped together at every release.
+The workspace ships eleven crates at version 0.11.1. The workspace
+version keeps their release numbers aligned.
 
 | Crate | Purpose |
 | --- | --- |
 | [idiolect-records](./idiolect-records.md) | Generated record types for the `dev.idiolect.*` lexicons; `Record` trait; family modules. |
-| [idiolect-codegen](./idiolect-codegen.md) | Lexicon-driven Rust + TypeScript emitter; drift gate; breaking-change classifier. |
+| [idiolect-codegen](./idiolect-codegen.md) | Lexicon-driven Rust + TypeScript emitter; generated-source check; breaking-change classifier. |
 | [idiolect-lens](./idiolect-lens.md) | Resolve `PanprotoLens` records; run `apply_lens`. |
 | [idiolect-identity](./idiolect-identity.md) | DID resolution (`did:plc`, `did:web`). |
 | [idiolect-indexer](./idiolect-indexer.md) | Firehose consumer with pluggable stream / handler / cursor store. |
@@ -25,11 +25,8 @@ name and to docs.rs at
 `publish = false` and are consumed via a git or path reference;
 each crate page states which applies.
 
-## Policy
+## Reference boundary
 
-The pages in this section are editorial overviews: an opinionated
-summary of what each crate is for, the public types you reach for
-first, and the feature flags. They are not the authoritative
-per-symbol reference. The authoritative reference is the rendered
-rustdoc on docs.rs, linked at the top of every crate page. When
-this book and docs.rs disagree, docs.rs is right.
+These pages list the exported boundaries and feature flags. Use docs.rs
+for the three published crates. For workspace-only crates, build
+rustdoc from the checkout named at the top of the page.

--- a/docs/book/src/reference/crates/index.md
+++ b/docs/book/src/reference/crates/index.md
@@ -1,6 +1,6 @@
 # Crates
 
-The workspace ships eleven crates at version 0.11.1. The workspace
+The workspace ships eleven crates at version 0.12.0. The workspace
 version keeps their release numbers aligned.
 
 | Crate | Purpose |

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -1,15 +1,15 @@
 # HTTP query API
 
-Read-only endpoints exposed by `idiolect-orchestrator` under the
-`query-http` feature. All requests are `GET`. All responses are
-JSON.
+`idiolect-orchestrator` exposes this read-only endpoint set under the
+`query-http` feature. All requests are `GET`. Query endpoints return JSON;
+health checks and metrics return text.
 
 The route surface is generated from
 `orchestrator-spec/queries.json`. Each query maps onto **two**
 endpoints: a friendly REST path under `/v1/…` and an
 ATProto-style xrpc path under
 `/xrpc/dev.idiolect.query.<queryName>`. Both call the same
-handler. The snapshot below reflects the spec at v0.8.0.
+handler. The snapshot below reflects idiolect 0.11.1.
 
 ## Liveness and metrics
 
@@ -19,47 +19,55 @@ handler. The snapshot below reflects the spec at v0.8.0.
 | `GET /readyz` | 200 OK once the catalog has caught up. |
 | `GET /metrics` | Prometheus exposition. |
 | `GET /v1/stats` | Per-kind record counts. |
+| `GET /v1/verifications/sufficient?lens_uri=...&kinds=...&hold=true` | `{ sufficient, required_kinds, require_holds }`; `kinds` is comma-separated. |
 
 ## Generated query endpoints
 
 | REST path | xrpc path | Returns |
 | --- | --- | --- |
 | `GET /v1/bounties/open` | `/xrpc/dev.idiolect.query.openBounties` | Bounties whose status is `open`, `claimed`, or unset. |
-| `GET /v1/bounties/want-lens?...` | `/xrpc/dev.idiolect.query.bountiesForWantLens` | Bounties whose `wants` is a specific lens. |
+| `GET /v1/bounties/want-lens?source_uri=...&target_uri=...` | `/xrpc/dev.idiolect.query.bountiesForWantLens` | Bounties requesting a lens for the schema pair. |
 | `GET /v1/bounties/by-requester?requester_did=...` | `/xrpc/dev.idiolect.query.bountiesByRequester` | Bounties by requester DID. |
 | `GET /v1/adapters?framework=...` | `/xrpc/dev.idiolect.query.adaptersForFramework` | Adapters declared for a framework. |
-| `GET /v1/adapters/by-invocation-protocol?...` | `/xrpc/dev.idiolect.query.adaptersByInvocationProtocol` | Adapters by invocation-protocol kind. |
-| `GET /v1/adapters/with-verification?...` | `/xrpc/dev.idiolect.query.adaptersWithVerification` | Adapters that carry at least one verification record. |
+| `GET /v1/adapters/by-invocation-protocol?kind=...` | `/xrpc/dev.idiolect.query.adaptersByInvocationProtocol` | Adapters by invocation-protocol kind. |
+| `GET /v1/adapters/with-verification` | `/xrpc/dev.idiolect.query.adaptersWithVerification` | Adapters that carry a verification reference. |
 | `GET /v1/recommendations` | `/xrpc/dev.idiolect.query.recommendationsStartingFrom` | Recommendations starting from a given source schema. |
 | `GET /v1/verifications?lens_uri=...` | `/xrpc/dev.idiolect.query.verificationsForLens` | Verifications for a specific lens. |
-| `GET /v1/verifications/by-kind?...` | `/xrpc/dev.idiolect.query.verificationsByKind` | Verifications by kind. |
-| `GET /v1/communities?...` | `/xrpc/dev.idiolect.query.communitiesForMember` | Communities for a member DID. |
-| `GET /v1/communities/by-name?...` | `/xrpc/dev.idiolect.query.communitiesByName` | Communities by name. |
-| `GET /v1/dialects/for-community?...` | `/xrpc/dev.idiolect.query.dialectsForCommunity` | Dialects owned by a community. |
-| `GET /v1/beliefs/about?...` | `/xrpc/dev.idiolect.query.beliefsAboutRecord` | Beliefs whose subject is a given record. |
-| `GET /v1/beliefs/by-holder?...` | `/xrpc/dev.idiolect.query.beliefsByHolder` | Beliefs by holder DID. |
-| `GET /v1/vocabularies/by-world?...` | `/xrpc/dev.idiolect.query.vocabulariesWithWorld` | Vocabularies declared with a given `world`. |
-| `GET /v1/vocabularies/by-name?...` | `/xrpc/dev.idiolect.query.vocabulariesByName` | Vocabularies by name. |
+| `GET /v1/verifications/by-kind?kind=...` | `/xrpc/dev.idiolect.query.verificationsByKind` | Verifications by kind. |
+| `GET /v1/communities?member_did=...` | `/xrpc/dev.idiolect.query.communitiesForMember` | Communities for a member DID. |
+| `GET /v1/communities/by-name?name=...` | `/xrpc/dev.idiolect.query.communitiesByName` | Communities by case-insensitive name. |
+| `GET /v1/dialects/for-community?community_uri=...` | `/xrpc/dev.idiolect.query.dialectsForCommunity` | Dialects owned by a community. |
+| `GET /v1/beliefs/about?subject_uri=...` | `/xrpc/dev.idiolect.query.beliefsAboutRecord` | Beliefs whose subject is a given record. |
+| `GET /v1/beliefs/by-holder?holder_did=...` | `/xrpc/dev.idiolect.query.beliefsByHolder` | Beliefs by holder DID. |
+| `GET /v1/vocabularies/by-world?world=...` | `/xrpc/dev.idiolect.query.vocabulariesWithWorld` | Vocabularies declared with a given `world`. |
+| `GET /v1/vocabularies/by-name?name=...` | `/xrpc/dev.idiolect.query.vocabulariesByName` | Vocabularies by exact name. |
 
 The authoritative parameter list per endpoint is in
 [`orchestrator-spec/queries.json`](https://github.com/idiolect-dev/idiolect/blob/main/orchestrator-spec/queries.json).
 The codegen-emitted handlers live in
 `crates/idiolect-orchestrator/src/generated/http.rs`.
 
-## Response shape
+## Pagination and response shape
 
-List endpoints return a JSON envelope whose exact shape is
-generated per query. The general pattern: a top-level object
-carrying the result list plus pagination metadata. See the
-emitted Rust types in
-`crates/idiolect-orchestrator/src/generated/` for the precise
-shape per endpoint.
+Every generated list endpoint accepts `limit` (default 100, maximum
+1000) and `offset` (default 0). Its response is:
+
+```json
+{
+  "items": [
+    { "uri": "at://did:plc:example/dev.idiolect.bounty/3l5", "author": "did:plc:example", "rev": "3l5", "record": {} }
+  ],
+  "total": 1,
+  "limit": 100,
+  "offset": 0
+}
+```
 
 ## Error shape
 
-A request that fails parameter validation returns 400 with a
-JSON body identifying the offending field. Internal failures
-return 500 with a brief message.
+A request that fails parameter validation returns 400; internal
+failures return 500. Both use `{ "error": "<code>", "message":
+"<detail>" }`.
 
 ## Versioning
 

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -9,7 +9,7 @@ The route surface is generated from
 endpoints: a friendly REST path under `/v1/…` and an
 ATProto-style xrpc path under
 `/xrpc/dev.idiolect.query.<queryName>`. Both call the same
-handler. The snapshot below reflects idiolect 0.11.1.
+handler. The snapshot below reflects idiolect 0.12.0.
 
 ## Liveness and metrics
 

--- a/docs/book/src/reference/index.md
+++ b/docs/book/src/reference/index.md
@@ -12,7 +12,7 @@ and HTTP contracts. Task procedures remain in the
 | [HTTP query API](./http-api.md) | Every endpoint exposed by the orchestrator, request and response shape. |
 | [Stability and versioning](./stability.md) | The pre-1.0 stability policy. |
 
-The reference covers idiolect 0.11.1 with panproto 0.70.1. For older
+The reference covers idiolect 0.11.1 with panproto 0.71.0. For older
 releases, use the
 [release archive](https://github.com/idiolect-dev/idiolect/releases).
 

--- a/docs/book/src/reference/index.md
+++ b/docs/book/src/reference/index.md
@@ -1,7 +1,8 @@
 # Reference
 
-Per-symbol detail. Use the navigation to jump to a specific crate,
-lexicon, CLI subcommand, or HTTP endpoint.
+Use this section to look up exported APIs, record fields, commands,
+and HTTP contracts. Task procedures remain in the
+[guides](../guide/index.md).
 
 | Section | Contents |
 | --- | --- |
@@ -11,15 +12,29 @@ lexicon, CLI subcommand, or HTTP endpoint.
 | [HTTP query API](./http-api.md) | Every endpoint exposed by the orchestrator, request and response shape. |
 | [Stability and versioning](./stability.md) | The pre-1.0 stability policy. |
 
-The reference covers the `0.8.0` release. For older releases, see
-the
+The reference covers idiolect 0.11.1 with panproto 0.70.1. For older
+releases, use the
 [release archive](https://github.com/idiolect-dev/idiolect/releases).
+
+## Extension and API path
+
+For an advanced integration, follow the lookup path that matches the
+extension boundary:
+
+| Extension boundary | Start here | Then inspect |
+| --- | --- | --- |
+| Add a record family or emitter target | [`idiolect-codegen`](./crates/idiolect-codegen.md) | [`RecordFamily`](./crates/idiolect-records.md#family) and the emit functions |
+| Add a stream, handler, or cursor backend | [`idiolect-indexer`](./crates/idiolect-indexer.md) | Trait signatures, feature flags, and error variants |
+| Add a lens resolver or schema loader | [`idiolect-lens`](./crates/idiolect-lens.md) | Resolver, loader, apply-input, and apply-output types |
+| Add an observation or verification method | [`idiolect-observer`](./crates/idiolect-observer.md) or [`idiolect-verify`](./crates/idiolect-verify.md) | Generated taxonomies and implementation traits |
+| Integrate over process boundaries | [CLI](./cli.md) or [HTTP API](./http-api.md) | Exact flags, query parameters, response envelopes, and errors |
+
+For wire-level extensions, begin with the [lexicon index](./lexicons/index.md)
+and follow each page's source link to the authoritative JSON.
 
 ## Authority policy
 
-This section is editorial. For Rust crates, the authoritative
-per-symbol reference is the rendered rustdoc on docs.rs (linked at
-the top of every crate page). For lexicons, the authoritative
-shape is the JSON document under `lexicons/dev/idiolect/`. When
-this book and either source disagree, the source wins. Please
-file an issue.
+For published Rust crates, rustdoc on docs.rs is authoritative. For
+workspace-only crates, build rustdoc from the current checkout. The
+JSON under `lexicons/dev/idiolect/` defines record shape. If this book
+disagrees with either source, use the source and file an issue.

--- a/docs/book/src/reference/index.md
+++ b/docs/book/src/reference/index.md
@@ -12,7 +12,7 @@ and HTTP contracts. Task procedures remain in the
 | [HTTP query API](./http-api.md) | Every endpoint exposed by the orchestrator, request and response shape. |
 | [Stability and versioning](./stability.md) | The pre-1.0 stability policy. |
 
-The reference covers idiolect 0.11.1 with panproto 0.71.0. For older
+The reference covers idiolect 0.12.0 with panproto 0.71.0. For older
 releases, use the
 [release archive](https://github.com/idiolect-dev/idiolect/releases).
 

--- a/docs/book/src/reference/lexicons/adapter.md
+++ b/docs/book/src/reference/lexicons/adapter.md
@@ -1,11 +1,10 @@
 # dev.idiolect.adapter
 
-A subprocess or HTTP-endpoint wrapper for a framework's tooling,
-authored by incentive-aligned parties. Adapters are how idiolect
-glues existing frameworks (Hasura, Prisma, Datomic, FHIR, Coq,
-Meilisearch, ...) without forking them. The adapter declaration
-is a published record. The orchestrator runs the adapter under
-the declared isolation policy.
+A published [record](../../glossary.md#record) that declares how to
+invoke a framework wrapper and what isolation it requests. The
+shipped orchestrator catalogs these declarations; it does not execute
+adapters or enforce their isolation policies. A separate adapter host
+must interpret and enforce the contract.
 
 > **Source:** [`lexicons/dev/idiolect/adapter.json`](https://github.com/idiolect-dev/idiolect/blob/main/lexicons/dev/idiolect/adapter.json)
 > · **Rust:** [`idiolect_records::Adapter`](https://docs.rs/idiolect-records/latest/idiolect_records/struct.Adapter.html)
@@ -16,10 +15,10 @@ the declared isolation policy.
 
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `framework` | string (≤128) | yes | Canonical framework name (e.g. `hasura`, `prisma`, `coq`). |
+| `framework` | string (at most 128 characters) | yes | Canonical framework name (e.g. `hasura`, `prisma`, `coq`). |
 | `versionRange` | string | yes | Semver range supported. |
 | `invocationProtocol` | object | yes | How the adapter is invoked. |
-| `isolation` | object | yes | Sandboxing requirements the orchestrator must honour. |
+| `isolation` | object | yes | Sandboxing requirements an adapter host is expected to enforce. |
 | `author` | did | yes | DID of the adapter author. |
 | `verification` | at-uri | no | Optional verification record demonstrating conformance. |
 | `occurredAt` | datetime | yes | Publication timestamp. |
@@ -44,34 +43,27 @@ the declared isolation policy.
 | `networkPolicyVocab` | `vocabRef` | no | Vocab the policy slug resolves against. |
 | `filesystemPolicy` | open enum | no | `readonly` / `scratch` / `writable-subtree` / `full`. |
 | `filesystemPolicyVocab` | `vocabRef` | no | Vocab the policy slug resolves against. |
-| `resourceLimits` | `{ maxMemoryBytes?, maxCpuSeconds?, maxWallSeconds? }` | no | Hard ceilings the orchestrator enforces. |
+| `resourceLimits` | `{ maxMemoryBytes?, maxCpuSeconds?, maxWallSeconds? }` | no | Requested ceilings for the adapter host. |
 
 ## Field details
 
-### Why an adapter is a record
+### Contract semantics
 
-An adapter is a *declared contract*: the publisher asserts that
-"this framework, at this version range, can be invoked via this
-protocol under this isolation policy". The orchestrator running
-the adapter trusts the contract only as far as it trusts the
-publisher's signature. Verification records can pin specific
-conformance claims.
-
-The alternative (each orchestrator hand-coding adapter wrappers
-per framework) does not scale. The adapter record is the
-declarative replacement: a community with framework expertise
-publishes the wrapper once, and orchestrators pick it up from the
-network.
+The publisher asserts that a framework in `versionRange` supports
+the declared invocation protocol under the requested isolation
+policy. Cataloging the record does not verify that assertion.
+Consumers may use linked verification records to evaluate specific
+conformance claims before passing the record to an adapter host.
 
 ### `invocationProtocol.kind`
 
-The transport over which the orchestrator drives the adapter:
+The transport an adapter host uses:
 
 | Slug | What it means |
 | --- | --- |
-| `subprocess` | The orchestrator forks `entryPoint` as a child process and pipes JSON over stdin/stdout. |
-| `http` | The orchestrator POSTs JSON to the URL at `entryPoint`. |
-| `wasm` | The orchestrator instantiates the WASM module at `entryPoint` and calls a designated export. |
+| `subprocess` | Fork `entryPoint` as a child process and exchange JSON over standard input and output. |
+| `http` | Send JSON to the URL at `entryPoint`. |
+| `wasm` | Instantiate the WebAssembly module at `entryPoint` and call the host-defined export. |
 
 The slug is open-enum: a community publishing a vocab with an
 additional kind (e.g. `nats-rpc`, `grpc-stream`) extends the
@@ -79,7 +71,7 @@ transport set without modifying the lexicon.
 
 ### `isolation.kind`
 
-The sandboxing posture the orchestrator must honour:
+The sandboxing posture requested from an adapter host:
 
 | Slug | What it means |
 | --- | --- |
@@ -89,10 +81,9 @@ The sandboxing posture the orchestrator must honour:
 | `vm` | Run in a full VM. |
 | `wasm-sandbox` | Run in a WASM runtime with capability-based access. |
 
-The orchestrator's policy is to refuse any adapter whose
-`isolation.kind` is weaker than its configured floor. An
-orchestrator configured for `container` minimum will not run an
-adapter declaring `process`.
+The lexicon does not define an ordering among these values or a
+minimum-isolation policy. A host that treats them as ordered must
+document that local policy.
 
 ### Network and filesystem policies
 
@@ -112,15 +103,13 @@ Orthogonal axes layered on top of the kind:
 | `writable-subtree` | The adapter writes to a designated subtree. |
 | `full` | Unrestricted. |
 
-The orchestrator's enforcement is best-effort and depends on the
-underlying isolation runtime. For example, `wasm-sandbox` makes
-`egress-allowlist` cheap and exact, while `process` makes it
-harder.
+These fields declare requested capabilities; enforcement depends on
+the adapter host and its isolation runtime. Consumers should not
+infer enforcement from the existence of the record.
 
 ### `resourceLimits`
 
-Hard ceilings. The orchestrator kills the adapter if it exceeds
-any of:
+Requested ceilings for a host that supports resource accounting:
 
 | Field | Unit |
 | --- | --- |

--- a/docs/book/src/reference/lexicons/belief.md
+++ b/docs/book/src/reference/lexicons/belief.md
@@ -3,7 +3,8 @@
 A signed doxastic claim that a referenced record is true or
 applicable. Belief records are how third parties represent what
 *they* think about *another* record without flattening provenance:
-the `subject` strong-ref pins the exact referenced record, the
+the `subject` [strong reference](../../glossary.md#strong-reference)
+pins the exact referenced record, the
 `holder` identifies the party whose attitude is represented, and
 the `basis` records what grounds it.
 
@@ -19,7 +20,7 @@ the `basis` records what grounds it.
 | `subject` | `strongRecordRef` | yes | AT-URI + CID for the record the belief is about. |
 | `holder` | did | no | Party whose attitude is represented. Omit for first-party. |
 | `basis` | `basis` | no | Structured grounding (load-bearing when `holder` differs from the repo owner). |
-| `annotations` | string (≤4000 graphemes) | no | Narrative commentary. |
+| `annotations` | string (at most 4,000 graphemes) | no | Narrative commentary. |
 | `visibility` | `visibility` | no | Visibility scope. |
 | `occurredAt` | datetime | yes | When the belief was published. |
 
@@ -61,7 +62,7 @@ on what grounds the attribution rests. The four `basis` variants:
 
 See [`defs#basis`](./defs.md) for the field shapes.
 
-### Use as a labeler primitive
+### Labeler use
 
 A labeler workflow that wants to record "a third party endorses
 this lens for a particular use" uses three records:
@@ -83,7 +84,7 @@ signature on the belief makes the attribution accountable.
   "$type": "dev.idiolect.belief",
   "subject": {
     "uri": "at://did:plc:other-party/dev.idiolect.recommendation/3l5",
-    "cid": "bafy..."
+    "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
   },
   "holder": "did:plc:other-party",
   "basis": {
@@ -97,7 +98,7 @@ signature on the belief makes the attribution accountable.
 }
 ```
 
-## How beliefs compose
+## Related records
 
 ```mermaid
 flowchart LR
@@ -106,7 +107,7 @@ flowchart LR
     B -->|holder| H[holder DID]
     B -->|basis| G[community policy]
     R -->|signed by| C[community]
-    C -.recognised by.-> H
+    C -.recognized by.-> H
 ```
 
 A consumer reading the belief sees: which record is being

--- a/docs/book/src/reference/lexicons/bounty.md
+++ b/docs/book/src/reference/lexicons/bounty.md
@@ -1,9 +1,9 @@
 # dev.idiolect.bounty
 
-A declaration that a translation, verification, or adapter is
+A declaration that a [lens](../../glossary.md#lens), verification, or adapter is
 wanted, with terms. idiolect does not intermediate fulfillment:
 payment, review, and acceptance happen on external rails referenced
-in the record. The record is the *request* primitive.
+in the record.
 
 > **Source:** [`lexicons/dev/idiolect/bounty.json`](https://github.com/idiolect-dev/idiolect/blob/main/lexicons/dev/idiolect/bounty.json)
 > · **Rust:** [`idiolect_records::Bounty`](https://docs.rs/idiolect-records/latest/idiolect_records/struct.Bounty.html)
@@ -16,9 +16,9 @@ in the record. The record is the *request* primitive.
 | --- | --- | --- | --- |
 | `requester` | did | yes | Who is requesting. |
 | `wants` | union | yes | Exactly one of `wantLens` / `wantVerification` / `wantAdapter`. |
-| `constraints` | array (≤64) | no | Structured constraints the deliverable must satisfy. |
+| `constraints` | array (at most 64 entries) | no | Structured constraints the deliverable must satisfy. |
 | `reward` | object | no | `{ summary?, externalRef? }`. idiolect does not transact. |
-| `eligibility` | array (≤128) | no | Postfix eligibility tree. |
+| `eligibility` | array (at most 128 entries) | no | Postfix eligibility tree. |
 | `fulfillment` | at-uri | no | Once fulfilled, points to the deliverable record. |
 | `status` | open enum | no | `open` / `claimed` / `fulfilled` / `withdrawn`. |
 | `statusVocab` | `vocabRef` | no | Vocab the status slug resolves against. |
@@ -53,7 +53,7 @@ Asks for an adapter for a framework.
 
 | Subfield | Type | Required | Notes |
 | --- | --- | --- | --- |
-| `framework` | string (≤128) | yes | Framework name. |
+| `framework` | string (at most 128 characters) | yes | Framework name. |
 | `versionRange` | string | no | Semver range. |
 
 ## The constraint variants
@@ -62,9 +62,9 @@ Each entry in `constraints` is one of:
 
 | Variant | Captures |
 | --- | --- |
-| `constraintPerformance` | A quantitative bound: metric, threshold, comparison direction (`lt`, `le`, `eq`, `ge`, `gt`), optional sample size. Examples: `p99-latency-ms ≤ 50`, `error-rate < 0.001`. |
+| `constraintPerformance` | A quantitative bound: metric, threshold, comparison direction (`lt`, `le`, `eq`, `ge`, `gt`), optional sample size. For instance, `p99-latency-ms le 50` or `error-rate lt 0.001`. |
 | `constraintConformance` | A verification kind (and optional specific property) the deliverable must pass. |
-| `constraintLicense` | An SPDX expression plus optional allow / deny lists. |
+| `constraintLicense` | An [SPDX license expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/) plus optional allow and deny lists. |
 | `constraintDeadline` | A datetime deadline plus optional grace seconds. |
 | `constraintDependency` | A pointer to another bounty this one waits on. Claims are ineligible until the dependency's status is `fulfilled`. |
 
@@ -101,11 +101,12 @@ prose. `externalRef` is a URL pointing at the rail that handles
 the actual reward (a grant portal, a payment platform, an
 attestation service). idiolect does not validate that the
 external rail exists, that it is solvent, or that the reward will
-be paid. That is the consumer's diligence.
+be paid. Consumers must verify the external rail and its payment
+terms themselves.
 
-The pattern: a bounty with `externalRef` pointing at a known
-grant portal is more credible than a bounty with only a narrative
-summary. Consumers route their effort accordingly.
+An `externalRef` to a known grant portal gives consumers a payment
+claim they can check; a narrative-only reward does not. Consumers
+can route their effort on that distinction.
 
 ### `fulfillment`
 
@@ -142,7 +143,7 @@ prior recommendation that listed required verifications).
       "kind": "roundtrip-test",
       "property": {
         "$type": "dev.idiolect.defs#lpRoundtrip",
-        "domain": "all valid v1 records with bodies ≤ 1024 bytes"
+        "domain": "all valid v1 records with bodies at most 1024 bytes"
       }
     },
     { "$type": "dev.idiolect.bounty#constraintDeadline",
@@ -162,7 +163,7 @@ prior recommendation that listed required verifications).
 }
 ```
 
-## How bounties drive verification work
+## Related records
 
 ```mermaid
 flowchart LR

--- a/docs/book/src/reference/lexicons/community.md
+++ b/docs/book/src/reference/lexicons/community.md
@@ -1,6 +1,6 @@
 # dev.idiolect.community
 
-A group of DIDs that declare shared conventions. Self-constituted:
+A group of [DIDs](../../glossary.md#did) that declare shared conventions. Self-constituted:
 there is no central roll and no grading of legitimacy. Communities
 may be small and many.
 
@@ -23,7 +23,7 @@ may be small and many.
 | `membershipRoll` | at-uri | no | External membership record (for communities above ~200 members). |
 | `coreSchemas` | array of `schemaRef` | no | Schemas the community treats as canonical. |
 | `coreLenses` | array of `lensRef` | no | Lenses the community treats as canonical. |
-| `endorsedCommunities` | array of at-uri | no | Other communities recognised as legitimate interlocutors. Not transitive. |
+| `endorsedCommunities` | array of at-uri | no | Other communities recognized as legitimate interlocutors. Not transitive. |
 | `conventions` | array (≤64) of structured convention variants | no | Decidable subset of community conventions. |
 | `conventionsText` | string (≤10000 graphemes) | no | Narrative conventions: style guides, norms not expressible structurally. |
 | `createdAt` | datetime | yes | Publication timestamp. |
@@ -56,7 +56,7 @@ predicate live in `conventionsText`.
 
 ### `members` versus `membershipRoll`
 
-Two ways to represent membership:
+Membership has two representations:
 
 - **Inline `members`** is appropriate for small communities. The
   list lives directly on the community record; reading the
@@ -97,7 +97,7 @@ through the AppView instead of crawling member PDSes.
 
 ### `endorsedCommunities`
 
-A community lists other communities it recognises as legitimate
+A community lists other communities it recognizes as legitimate
 interlocutors. The endorsement is *not* transitive: A endorsing B
 and B endorsing C does not imply A endorsing C. The record only
 states the assertion. Consumers decide what to do with it. Common

--- a/docs/book/src/reference/lexicons/correction.md
+++ b/docs/book/src/reference/lexicons/correction.md
@@ -1,9 +1,9 @@
 # dev.idiolect.correction
 
-A signed record of a post-translation edit. Corrections are the
+A signed [record](../../glossary.md#record) of a post-translation edit. Corrections are the
 primary signal an observer uses to detect lens quality issues;
-the reason taxonomy decouples "lens was wrong" from "the world
-is complicated".
+the reason taxonomy distinguishes lens errors from domain differences,
+source errors, downstream requirements, and invocation mistakes.
 
 > **Source:** [`lexicons/dev/idiolect/correction.json`](https://github.com/idiolect-dev/idiolect/blob/main/lexicons/dev/idiolect/correction.json)
 > · **Rust:** [`idiolect_records::Correction`](https://docs.rs/idiolect-records/latest/idiolect_records/struct.Correction.html)
@@ -15,12 +15,12 @@ is complicated".
 | Field | Type | Required | Notes |
 | --- | --- | --- | --- |
 | `encounter` | `encounterRef` | yes | The encounter whose output was edited. |
-| `path` | string (≤1024) | yes | JSON Pointer or equivalent into the produced output. |
+| `path` | string (at most 1,024 characters) | yes | JSON Pointer or equivalent into the produced output. |
 | `originalValue` | unknown | no | Value prior to correction. May be elided for visibility reasons. |
 | `correctedValue` | unknown | no | Value after correction. |
 | `reason` | open enum | yes | `lens-error` / `domain-difference` / `source-error` / `downstream-idiosyncrasy` / `user-mistake` / `retrospective`. |
 | `reasonVocab` | `vocabRef` | no | Vocab the reason slug resolves against. |
-| `rationale` | string (≤2000 graphemes) | no | Human-readable justification. |
+| `rationale` | string (at most 2,000 graphemes) | no | Human-readable justification. |
 | `holder` | did | no | Party the correction is attributed to. |
 | `basis` | `basis` | no | Structured grounding for third-party attribution. |
 | `visibility` | `visibility` | yes | Visibility scope. |
@@ -28,7 +28,7 @@ is complicated".
 
 ## Field details
 
-### Why a `reason` taxonomy
+### `reason`
 
 Aggregating corrections naively gives the wrong signal: a lens
 that produces correct output for half its inputs and
@@ -79,19 +79,19 @@ machinery, identical to encounter and belief.
   "$type": "dev.idiolect.correction",
   "encounter": {
     "uri": "at://did:plc:user/dev.idiolect.encounter/3l5",
-    "cid": "bafy..."
+    "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
   },
   "path": "/body/text",
   "originalValue": "the quick brown foxes",
   "correctedValue": "the quick brown fox",
   "reason": "lens-error",
-  "rationale": "Lens incorrectly pluralised the singular noun.",
+  "rationale": "Lens incorrectly pluralized the singular noun.",
   "visibility": "public-detailed",
   "occurredAt": "2026-04-19T00:00:00.000Z"
 }
 ```
 
-## How corrections feed observation
+## Related records
 
 ```mermaid
 flowchart LR
@@ -104,9 +104,8 @@ flowchart LR
 A high `lens-error` count in observations is a signal. A high
 `domain-difference` count is just a record of community
 disagreement. Consumers reading observations make routing
-decisions on the former, not the latter; observers therefore
-must publish the breakdown by reason, not just a flat correction
-count.
+decisions on the former, not the latter. Thus, observers must publish
+the breakdown by reason, not just a flat correction count.
 
 ## Concept references
 

--- a/docs/book/src/reference/lexicons/defs.md
+++ b/docs/book/src/reference/lexicons/defs.md
@@ -1,11 +1,11 @@
 # dev.idiolect.defs
 
-Shared types for the `dev.idiolect.*` lexicon family. Two kinds of
-content live here:
+This document defines shared types for the `dev.idiolect.*`
+[lexicon](../../glossary.md#lexicon) family. Two kinds of content live here:
 
-- **Cross-cutting reference shapes** — lens, schema, encounter,
+- **Cross-cutting reference shapes:** lens, schema, encounter,
   vocab, and strong-record references; tool identity; visibility.
-- **Content-theory types** — purpose, lens property, evidence,
+- **Content-theory types:** purpose, lens property, evidence,
   caveat, basis. Shared across multiple records.
 
 Record-specific combinator trees (condition, eligibility,
@@ -78,7 +78,7 @@ A closed-enum string. Five values:
 | `public-detailed` | Full record body published. |
 | `public-minimal` | Record published with elided detail (e.g. omits source instance). |
 | `public-aggregate-only` | Record consumed only by aggregators; individual reads suppressed. |
-| `community-scoped` | Reserved for v1 substrate enforcement; should not be served to parties outside the named community once enforcement lands. |
+| `community-scoped` | Declares an intended community scope. The current runtime does not enforce access control for this value. |
 | `private` | Should not be published at all. |
 
 idiolect does not enforce these today. They are policy

--- a/docs/book/src/reference/lexicons/deliberation.md
+++ b/docs/book/src/reference/lexicons/deliberation.md
@@ -1,6 +1,6 @@
 # dev.idiolect.deliberation
 
-A community-scoped question or proposal under collective
+A community-scoped [record](../../glossary.md#record) for a question or proposal under collective
 consideration. Companion records carry the rest of the process:
 [`deliberationStatement`](./deliberationStatement.md) for
 participant utterances,
@@ -34,7 +34,7 @@ consumers can read the conclusion without re-folding the votes.
 | `status` | open enum | no | `open` / `closed` / `tabled` / `adopted` / `rejected`. |
 | `statusVocab` | `vocabRef` | no | Vocab the status slug resolves against. |
 | `closedAt` | datetime | no | When the deliberation moved out of an open status. |
-| `outcome` | at-uri | no | Pointer to a `deliberationOutcome` record summarising the resolved stance. |
+| `outcome` | at-uri | no | Pointer to a `deliberationOutcome` record summarizing the resolved stance. |
 | `createdAt` | datetime | yes | Publication timestamp. |
 
 ## Field details

--- a/docs/book/src/reference/lexicons/deliberationOutcome.md
+++ b/docs/book/src/reference/lexicons/deliberationOutcome.md
@@ -1,8 +1,10 @@
 # dev.idiolect.deliberationOutcome
 
-Observer-aggregated tally for a [`deliberation`](./deliberation.md).
-Not a participant-authored record: produced by an observer fold
-over the vote stream and published from the observer's repo.
+`dev.idiolect.deliberationOutcome` is an observer-aggregated tally for a
+[`deliberation`](./deliberation.md), pinned through a
+[strong reference](../../glossary.md#strong-reference).
+An observer, rather than a participant, produces this record by folding the
+vote stream and publishing the result from the observer's repository.
 Consumers reading a closed deliberation can fetch the outcome
 directly rather than re-folding every vote. Tallies are
 per-statement and per-stance, so consumers can render a
@@ -42,24 +44,24 @@ Polis-style opinion map without further computation.
 
 ## Field details
 
-### Why outcomes are observer-published
+### Publisher
 
 The deliberation owns the topic. Participants own the statements
 and votes. The aggregate is *opinion*: it depends on the
 observer's fold method, the cut-off time, and which encounter
-kinds it weights. Two observers can produce different but
-defensible outcomes for the same deliberation.
+kinds it weights. Two observers can produce different outcomes for the same
+deliberation.
 
-The answer is that outcomes are records, signed by the observer
-and comparable across observers. A consumer that distrusts
-one observer's fold can:
+Outcomes are signed observer records, so consumers can identify their
+publishers and compare compatible folds. A consumer that distrusts one
+observer's fold can:
 
 - Fetch all outcomes for the deliberation.
 - Pick one based on the observer's identity or the `tool` field.
 - Require quorum among trusted observers.
 - Re-fold the vote stream itself.
 
-### Why a single `stanceVocab` per outcome
+### `stanceVocab`
 
 The outcome record uses *one* stance vocabulary across all
 tallies. An observer that sees votes referencing different
@@ -68,7 +70,7 @@ vocabularies must either:
 - Publish separate outcomes per vocab, each tallying votes that
   share a vocab.
 - First translate via a `mapEnum` lens (see
-  [Open enums](../../concepts/open-enums.md)) into a single
+  [Open enums](../../concepts/open-enums.md) into a single
   target vocabulary, then tally.
 
 Mixing vocabularies in a single outcome is invalid: the same
@@ -77,7 +79,7 @@ adding their counts is meaningless.
 
 ### `statementTallies`
 
-One entry per statement that received at least one vote.
+The array contains one entry per statement that received at least one vote.
 Statements with zero votes are omitted. Each tally carries:
 
 - The statement (strong-ref, so consumers fetching the tally can
@@ -111,11 +113,9 @@ adoption (rejected, tabled, or closed without resolution).
 ### `tool` and method versioning
 
 The `tool` field carries the aggregator's identity and version.
-Two outcomes for the same deliberation produced by different
-tools (or different versions of the same tool) are not directly
-comparable: the algorithm differs. Consumers compare outcomes
-across tools at their own risk. The record carries the tool
-identity so the comparison is at least informed.
+Different tools or versions may implement different algorithms. Consumers
+should compare their outcomes only when the method semantics align; the `tool`
+field identifies the implementation used.
 
 ## Example
 
@@ -124,13 +124,13 @@ identity so the comparison is at least informed.
   "$type": "dev.idiolect.deliberationOutcome",
   "deliberation": {
     "uri": "at://did:plc:community/dev.idiolect.deliberation/3l5",
-    "cid": "bafy..."
+    "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
   },
   "statementTallies": [
     {
       "statement": {
         "uri": "at://did:plc:community/dev.idiolect.deliberationStatement/stmt1",
-        "cid": "bafy..."
+        "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
       },
       "counts": [
         { "stance": "agree",    "count": 42 },
@@ -141,7 +141,7 @@ identity so the comparison is at least informed.
     {
       "statement": {
         "uri": "at://did:plc:community/dev.idiolect.deliberationStatement/stmt2",
-        "cid": "bafy..."
+        "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
       },
       "counts": [
         { "stance": "agree",    "count": 18 },
@@ -153,7 +153,7 @@ identity so the comparison is at least informed.
   "adopted": [
     {
       "uri": "at://did:plc:community/dev.idiolect.deliberationStatement/stmt1",
-      "cid": "bafy..."
+      "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
     }
   ],
   "computedAt": "2026-04-30T00:00:00.000Z",

--- a/docs/book/src/reference/lexicons/deliberationStatement.md
+++ b/docs/book/src/reference/lexicons/deliberationStatement.md
@@ -2,7 +2,8 @@
 
 A participant utterance submitted to a
 [`deliberation`](./deliberation.md). Statements are the units
-votes attach to. The deliberation itself is not voted on
+votes attach to. A [strong reference](../../glossary.md#strong-reference)
+pins the deliberation revision. The deliberation itself is not voted on
 directly. Classification is an open-enum slug resolved against a
 community vocabulary, so communities that draw the line between
 `claim` and `proposal` differently can extend or remap without
@@ -26,7 +27,7 @@ forking the lexicon.
 
 ## Field details
 
-### Why `strongRecordRef` for the deliberation pointer
+### `deliberation`
 
 `deliberation` carries both the AT-URI and the CID. Pinning by
 CID prevents a later deliberation revision from silently
@@ -85,7 +86,7 @@ its own access controls.
   "$type": "dev.idiolect.deliberationStatement",
   "deliberation": {
     "uri": "at://did:plc:community/dev.idiolect.deliberation/3l5",
-    "cid": "bafy..."
+    "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
   },
   "text": "Adopting the v2 lens would lose dialect markers on legacy posts.",
   "classification": "dissent",

--- a/docs/book/src/reference/lexicons/deliberationVote.md
+++ b/docs/book/src/reference/lexicons/deliberationVote.md
@@ -1,6 +1,7 @@
 # dev.idiolect.deliberationVote
 
-A stance taken on a [`deliberationStatement`](./deliberationStatement.md).
+A stance taken on a [`deliberationStatement`](./deliberationStatement.md),
+pinned by a [strong reference](../../glossary.md#strong-reference).
 Stance is an open-enum slug resolved against a community-published
 vote-stance vocabulary. The Acorn-style three-way default
 (`agree` / `pass` / `disagree`) is canonical. Richer vocabularies
@@ -27,7 +28,7 @@ Consumers that don't need them ignore them.
 
 ## Field details
 
-### Why pin the statement by CID
+### `subject`
 
 The `subject` field carries both AT-URI and CID. A statement
 edited after the vote was cast does not retroactively change what
@@ -64,7 +65,7 @@ to the canonical idiolect default.
 
 ### `weight`
 
-Optional ranking signal. The `[0, 1000]` integer range encodes
+The optional `weight` is a ranking signal. Its `[0, 1000]` integer range encodes
 the 0.0–1.0 floating-point range with three decimal places of
 precision. Convention follows `pub.chive.graph.edge#weight`.
 
@@ -76,7 +77,7 @@ quadratic-vote fold read both the stance and the weight.
 
 ### `rationale`
 
-Optional narrative. Tally folds do not consume `rationale`.
+The optional `rationale` is narrative. Tally folds do not consume it.
 Consumer surfaces (e.g. a deliberation viewer) display it
 alongside the vote. The 500-grapheme cap matches the
 deliberation-statement length: brevity is conventional.
@@ -96,7 +97,7 @@ signature is the authoritative provenance signal.
   "$type": "dev.idiolect.deliberationVote",
   "subject": {
     "uri": "at://did:plc:community/dev.idiolect.deliberationStatement/3l5",
-    "cid": "bafy..."
+    "cid": "bafyreidfcm4u3vnuph5ltwdpssiz3a4xfbm2otjrdisftwnbfmnxd6lsxm"
   },
   "stance": "agree",
   "weight": 750,
@@ -105,7 +106,7 @@ signature is the authoritative provenance signal.
 }
 ```
 
-## Folded into the outcome
+## Related records
 
 A vote does not produce an outcome on its own. An observer reads
 the vote stream for a deliberation, folds by `(statement, stance)`

--- a/docs/book/src/reference/lexicons/dialect.md
+++ b/docs/book/src/reference/lexicons/dialect.md
@@ -1,6 +1,6 @@
 # dev.idiolect.dialect
 
-A community's bundle of idiolect references and preferred
+A community's [dialect](../../glossary.md#dialect): a bundle of idiolect references and preferred
 translations. Dialects are declared, not imposed: downstream
 consumers may adopt, adapt, or ignore them.
 
@@ -34,7 +34,7 @@ consumers may adopt, adapt, or ignore them.
 
 ## Field details
 
-### What a dialect is
+### Contract semantics
 
 A dialect is a *bundle*. It does not introduce new lexicons; it
 collects existing ones into a coherent set the community treats
@@ -72,8 +72,9 @@ successor. Consumers reading a record at the deprecated `ref` can
 follow `replacement` to the new one, with the `reason` field
 explaining why.
 
-The lexicon-evolution policy generates deprecation entries
-automatically when a non-Iso lens revision ships. See
+The intended lexicon-evolution policy calls for a deprecation entry when a
+non-`Iso` lens revision ships; the current automation does not enforce this
+rule reliably. See
 [Lexicon evolution policy](../../concepts/lexicon-evolution.md).
 
 ## Example

--- a/docs/book/src/reference/lexicons/encounter.md
+++ b/docs/book/src/reference/lexicons/encounter.md
@@ -1,8 +1,7 @@
 # dev.idiolect.encounter
 
-A signed record of a single lens invocation. Encounters are the
-*emergent-channel* primitive: they record that a translation
-occurred, with enough context for aggregators (observations) and
+A signed [record](../../glossary.md#record) of a single [lens](../../glossary.md#lens) invocation. Encounters record that a
+translation occurred, with enough context for aggregators (observations) and
 correctors to reason about it. Narrative commentary lives in
 `annotations`. The structured payload in `use` covers the
 action / material / purpose / actor of the invocation.
@@ -48,7 +47,8 @@ end, by which actor" tuple. Consumers that match on actions
 match on *subsumption* against the referenced vocabulary, not on
 substring equality. Two communities that disagree on whether
 `train_model` subsumes `fine_tune` produce different routing
-decisions from the same encounter, which is the right answer.
+decisions from the same encounter, as expected when their vocabularies encode
+different subsumption relations.
 
 ### `kind`
 
@@ -63,10 +63,10 @@ The encounter-kind slug declares what the corpus represents:
 | `adversarial` | An invocation explicitly chosen to stress the lens. |
 
 Observers declare in their method which kinds they weight and
-how. An observation aggregating `invocation-log` plus `curated`
-encounters is meaningfully different from one aggregating only
-`adversarial` ones. The kind and the observer's method together
-determine how the observation should be read.
+how. An observation aggregating `invocation-log` and `curated` encounters has a
+different input distribution from one aggregating only `adversarial`
+encounters. The kind and the observer's method together determine how the
+observation should be read.
 
 ### `downstreamResult`
 
@@ -79,8 +79,8 @@ The invoking party's at-record-time assessment of the outcome:
 | `rejected` | The output was unusable. |
 | `unknown` | The party publishing did not know yet. |
 
-`corrected` is the link between the emergent-channel encounter
-record and the correction record that documents the edit.
+`corrected` links the encounter to the correction record that documents the
+edit.
 Consumers reading correction records traverse back through the
 encounter's `downstreamResult` to confirm the link.
 
@@ -96,11 +96,10 @@ the variants.
 
 ### `visibility`
 
-The five values are policy hints, not access control. idiolect
-does not enforce them today. Records marked
-`community-scoped` should not be served to parties outside the
-named community once scope enforcement lands. Records marked
-`private` should not be published at all.
+The five values are policy hints, not access control. The current
+runtime does not enforce them. `community-scoped` declares that
+consumers should not serve a record outside the named community;
+`private` declares that the record should remain local.
 
 ## Example
 
@@ -123,7 +122,7 @@ named community once scope enforcement lands. Records marked
 }
 ```
 
-## How encounters are consumed
+## Related records
 
 ```mermaid
 flowchart LR

--- a/docs/book/src/reference/lexicons/index.md
+++ b/docs/book/src/reference/lexicons/index.md
@@ -1,7 +1,7 @@
 # Lexicons
 
-The `dev.idiolect.*` lexicon family. Every record kind that travels
-on the network has a lexicon document under
+This section covers the `dev.idiolect.*` [lexicon](../../glossary.md#lexicon) family. Every record
+kind that travels on the network has a lexicon document under
 `lexicons/dev/idiolect/`.
 
 | NSID | Page |

--- a/docs/book/src/reference/lexicons/observation.md
+++ b/docs/book/src/reference/lexicons/observation.md
@@ -1,6 +1,6 @@
 # dev.idiolect.observation
 
-A signed aggregate over a set of encounter-family records.
+A signed aggregate over a [record family](../../glossary.md#record-family).
 Observations decouple ranking from the orchestrator: many
 observers publish competing aggregates over the same traces, and
 consumers choose whom to trust.
@@ -64,19 +64,18 @@ interpret the output. The `method.name`, `version`, and optional
 ### `scope.encounterKinds`
 
 The observer must disclose which encounter kinds it includes or
-the observation is uninterpretable. An observation that includes
-`adversarial` encounters at the same weight as `invocation-log`
-encounters is meaningfully different from one that excludes
-adversarial samples. Consumers reading the observation rely on
-this disclosure to decide whether the result fits their use case.
+the observation is uninterpretable. An observation that weights `adversarial`
+and `invocation-log` encounters equally has a different input distribution from
+one that excludes adversarial samples. Consumers reading the observation rely
+on this disclosure to decide whether the result fits their use case.
 
 ### `version` versus `occurredAt`
 
-`version` is the method's version. Two observations with the same
-`method.name` but different `version`s are not comparable: the
-algorithm changed. `occurredAt` is when the observation was
-published. Two observations with the same `version` but different
-`occurredAt`s are comparable as time-series data.
+`version` is the method's version. Different method versions may not be
+comparable because the algorithm or parameter semantics may have changed.
+`occurredAt` is when the observation was published. Observations with the same
+method and version are comparable as time-series data only when their scopes
+and parameters also align.
 
 ### `basis`
 
@@ -127,19 +126,14 @@ the relay or transformation kind.
 }
 ```
 
-## Why observations and not metrics
+## Trust semantics
 
-A central metrics endpoint cannot:
-
-- Be verified after the fact (the counter is whatever the endpoint
-  says it is).
-- Be re-folded by an independent party.
-- Disagree with itself across observers.
-
-A signed observation can. Two observers running the same fold on
-overlapping data will produce records with comparable counts.
-Consumers can require quorum among trusted observers before
-treating an observation as authoritative.
+A mutable metrics endpoint does not by itself preserve a signed, replayable
+snapshot. A signed observation records the publisher and can be re-folded when
+the input history and method are available. Observers may produce comparable
+counts when method version, scope, and input coverage align. Consumers can
+require quorum among trusted observers before treating an observation as
+authoritative.
 
 ## Concept references
 

--- a/docs/book/src/reference/lexicons/recommendation.md
+++ b/docs/book/src/reference/lexicons/recommendation.md
@@ -1,6 +1,6 @@
 # dev.idiolect.recommendation
 
-A community-published opinionated path with structured applicability
+A community-published [lens](../../glossary.md#lens) path with structured applicability
 conditions and optional verification requirements. The `conditions`,
 `preconditions`, and `caveats` arrays are *structured*: a consumer
 can evaluate them mechanically against an invocation context. The
@@ -105,8 +105,8 @@ A structured failure-mode list. Each `caveat` has:
 Consumers match on `mode` and `affects` to decide whether the
 caveat applies to their use case. `severity` is advisory; an
 `error` caveat is the community's notice that the recommendation
-should not be adopted in cases the caveat covers, and a consumer
-ignoring it is on its own.
+should not be adopted in cases the caveat covers. A consumer that ignores it
+accepts the failure mode named by the caveat.
 
 ## Example
 
@@ -127,7 +127,7 @@ ignoring it is on its own.
   ],
   "requiredVerifications": [
     { "$type": "dev.idiolect.defs#lpRoundtrip",
-      "domain": "all valid v1 records with bodies ≤ 1024 bytes" }
+      "domain": "all valid v1 records with bodies at most 1024 bytes" }
   ],
   "caveats": [
     { "mode": "loses-dialect-markers",
@@ -138,7 +138,7 @@ ignoring it is on its own.
 }
 ```
 
-## How recommendations route translations
+## Related records
 
 ```mermaid
 flowchart LR

--- a/docs/book/src/reference/lexicons/retrospection.md
+++ b/docs/book/src/reference/lexicons/retrospection.md
@@ -1,6 +1,6 @@
 # dev.idiolect.retrospection
 
-A signed annotation of a prior encounter with a delayed finding.
+A signed [record](../../glossary.md#record) that annotates a prior encounter with a delayed finding.
 Retrospections address silent-error latency: merges, migrations,
 and bitemporal reconciliations often surface failures only after
 long delay.
@@ -33,7 +33,7 @@ long delay.
 | `detail` | string (≤8000 graphemes) | yes | Narrative detail. |
 | `evidence` | union of `evidenceDivergence` / `evidenceLoss` / `evidenceMismatch` | no | Structured witness for the finding. |
 
-## Why a separate record kind
+## Finding timing
 
 Encounters are at-record-time. Corrections are short-loop. A
 retrospection covers the case where the finding surfaces *after*
@@ -75,14 +75,14 @@ Precomputed for aggregation convenience. The value is
 findings by latency (e.g. "what's the median time-to-detect for
 merge-divergence findings?") read this field directly. Authors
 may omit it for `kind: other` findings where latency is not
-meaningful.
+defined.
 
 ### `confidence`
 
-Optional, in `[0, 1]`. A finding the detecting party is sure of
-omits it. A finding hedged on uncertain evidence sets a value
-below 1. Aggregators may weight findings by confidence. Consumers
-treating findings as ground truth filter for high confidence.
+The optional value lies in `[0, 1]`. A finding the detecting party is sure of
+omits it, while a finding hedged on uncertain evidence sets a value below 1.
+Aggregators may weight findings by confidence. Consumers treating findings as
+ground truth filter for high confidence.
 
 ### `disputedAttribution`
 
@@ -112,7 +112,7 @@ the repo signer carry the relevant attribution.
   },
   "finding": {
     "kind": "data-loss",
-    "detail": "Lens dropped the `provenance` array on records with > 100 entries; not detected at write time because all sampled inputs had ≤ 50 entries.",
+    "detail": "Lens dropped the `provenance` array on records with more than 100 entries; not detected at write time because all sampled inputs had at most 50 entries.",
     "evidence": {
       "$type": "dev.idiolect.defs#evidenceLoss",
       "sourceField": "provenance",

--- a/docs/book/src/reference/lexicons/verification.md
+++ b/docs/book/src/reference/lexicons/verification.md
@@ -73,7 +73,7 @@ captures the falsification and lets consumers decide.
 
 The `tool` field records the tool's name, version, and optional
 commit. Consumers reading a verification can decide whether to
-trust the tool: `panproto-check@0.70.1` plus a known-good commit
+trust the tool: `panproto-check@0.71.0` plus a known-good commit
 is a different signal from a tool the consumer has never heard of.
 
 ### `verifier`
@@ -119,7 +119,7 @@ falsification independently.
   "verifier": "did:plc:verifier",
   "tool": {
     "name": "panproto-check",
-    "version": "0.70.1",
+    "version": "0.71.0",
     "commit": "02158abb"
   },
   "property": {

--- a/docs/book/src/reference/lexicons/verification.md
+++ b/docs/book/src/reference/lexicons/verification.md
@@ -1,9 +1,9 @@
 # dev.idiolect.verification
 
-A signed assertion of a formal property of a lens. Verifications
-are the *formal-channel* primitive: they coexist with the emergent
-channel (encounters, corrections, observations) and neither gates
-the other. `property` is a structured `lensProperty` (see
+A signed [verification](../../glossary.md#verification) of a formal property of a [lens](../../glossary.md#lens). Verifications
+record formal claims alongside operational evidence from encounters,
+corrections, and observations; neither evidence source gates the other.
+`property` is a structured `lensProperty` (see
 [`defs`](./defs.md)) so consumers dispatch on the specific claim:
 a `Theorem` for proof checkers, a `GeneratorSpec` for PBT runners,
 a `ConformanceStandard` for conformance runners, and so on.
@@ -49,10 +49,10 @@ together pin exactly what was verified.
 
 A consumer reading a verification record dispatches on `kind`,
 matches against the embedded `property`, and decides whether the
-specific verification meets its needs. A roundtrip-test verification
-that covers `domain: "all valid v1 records with bodies ≤ 1024 bytes"`
-is meaningfully different from one that covers `domain: "the
-training corpus"`; both are valid, neither subsumes the other.
+specific verification meets its needs. A roundtrip-test verification covering
+`domain: "all valid v1 records with bodies at most 1024 bytes"` tests a
+different input set from one covering `domain: "the training corpus"`; both
+are valid, and neither subsumes the other.
 
 ## Field details
 
@@ -73,7 +73,7 @@ captures the falsification and lets consumers decide.
 
 The `tool` field records the tool's name, version, and optional
 commit. Consumers reading a verification can decide whether to
-trust the tool: `panproto-check@0.39.0` plus a known-good commit
+trust the tool: `panproto-check@0.70.1` plus a known-good commit
 is a different signal from a tool the consumer has never heard of.
 
 ### `verifier`
@@ -119,12 +119,12 @@ falsification independently.
   "verifier": "did:plc:verifier",
   "tool": {
     "name": "panproto-check",
-    "version": "0.39.0",
+    "version": "0.70.1",
     "commit": "02158abb"
   },
   "property": {
     "$type": "dev.idiolect.defs#lpRoundtrip",
-    "domain": "all valid v1 records with bodies ≤ 1024 bytes",
+    "domain": "all valid v1 records with bodies at most 1024 bytes",
     "generator": "https://corpus.example/v1-1k-sample.zip"
   },
   "result": "holds",
@@ -132,7 +132,7 @@ falsification independently.
 }
 ```
 
-## Verifications and recommendations
+## Related records
 
 A `dev.idiolect.recommendation` lists `requiredVerifications`. A
 consumer adopting the recommendation queries the verifier registry

--- a/docs/book/src/reference/lexicons/vocab.md
+++ b/docs/book/src/reference/lexicons/vocab.md
@@ -1,6 +1,6 @@
 # dev.idiolect.vocab
 
-A community-published vocabulary. Two compatible shapes are
+A community-published [vocabulary](../../glossary.md#vocabulary). Two compatible shapes are
 supported:
 
 1. The legacy single-relation **tree** (`actions` + `top` + `world`),
@@ -16,8 +16,8 @@ vocabularies should prefer the graph shape. The tree stays valid
 for backward compatibility and remains a good fit for pure
 subsumption hierarchies.
 
-The graph shape is modelled after `pub.chive.graph.{node,edge}`,
-so cross-vocabulary translation, SKOS-style
+The graph shape is modeled after `pub.chive.graph.{node,edge}`,
+so cross-vocabulary translation, [SKOS](https://www.w3.org/TR/skos-reference/)-style
 `broader_than`/`narrower_than` mappings, and external-id
 alignment (Wikidata, ROR, ORCID, ...) are first-class.
 
@@ -85,7 +85,7 @@ metadata.
 | `notation` | string (≤500) | no | SKOS `notation`: non-text identifier. |
 | `externalIds` | array (≤20) of `externalId` | no | Mappings to external knowledge bases. |
 | `status` | open enum | no | `proposed` / `provisional` / `established` / `deprecated`. |
-| `relationMetadata` | `relationMetadata` | no | OWL Lite property characteristics. Required for `kind: relation`. |
+| `relationMetadata` | `relationMetadata` | no | [OWL 2](https://www.w3.org/TR/owl2-syntax/) property characteristics. Required for `kind: relation`. |
 
 ### `vocabNode.kind`
 
@@ -106,7 +106,7 @@ metadata.
 | `relationSlug` | string | yes | Relation slug. References a relation-kind node. |
 | `metadata` | unknown | no | Edge metadata, free-form. |
 
-## OWL Lite property characteristics
+## OWL property characteristics
 
 A `relation`-kind node carries metadata declaring algebraic
 properties:

--- a/docs/book/src/reference/stability.md
+++ b/docs/book/src/reference/stability.md
@@ -71,7 +71,7 @@ The Changelog is in
 | --- | --- | --- |
 | `idiolect-records` | crates.io | exact version |
 | `@idiolect-dev/schema` | npm | exact version |
-| panproto crates | Git tag | `v0.70.1` for idiolect 0.11.1 |
+| panproto crates | Git tag | `v0.71.0` for idiolect 0.11.1 |
 | `idiolect` CLI | binary release on GitHub | release tag |
 | `idiolect-orchestrator` container | `ghcr.io/idiolect-dev/orchestrator` | image SHA |
 | `idiolect-observer` container | `ghcr.io/idiolect-dev/observer` | image SHA |

--- a/docs/book/src/reference/stability.md
+++ b/docs/book/src/reference/stability.md
@@ -71,7 +71,7 @@ The Changelog is in
 | --- | --- | --- |
 | `idiolect-records` | crates.io | exact version |
 | `@idiolect-dev/schema` | npm | exact version |
-| panproto crates | Git tag | `v0.71.0` for idiolect 0.11.1 |
+| panproto crates | Git tag | `v0.71.0` for idiolect 0.12.0 |
 | `idiolect` CLI | binary release on GitHub | release tag |
 | `idiolect-orchestrator` container | `ghcr.io/idiolect-dev/orchestrator` | image SHA |
 | `idiolect-observer` container | `ghcr.io/idiolect-dev/observer` | image SHA |

--- a/docs/book/src/reference/stability.md
+++ b/docs/book/src/reference/stability.md
@@ -1,9 +1,8 @@
 # Stability and versioning
 
-idiolect is pre-1.0. Releases in the `0.x` series may include
-arbitrary breaking changes between minor versions: Rust APIs,
-lexicon shapes, wire formats, daemon HTTP routes, and CLI surfaces
-are all in scope.
+idiolect is pre-1.0. Minor releases in the `0.x` series may break Rust
+APIs, [lexicon](../glossary.md#lexicon "A schema document in the AT Protocol Lexicon language")
+shapes, wire formats, HTTP routes, and CLI flags.
 
 Pin to an exact version if you depend on this project. Read the
 [changelog](https://github.com/idiolect-dev/idiolect/blob/main/CHANGELOG.md)
@@ -13,9 +12,7 @@ before bumping.
 
 Pre-1.0:
 
-- **Trait signatures** can tighten or widen between minor
-  versions. The most recent example is the `Resolver` /
-  `SchemaLoader` Send bound in v0.8.0.
+- **Trait signatures** can tighten or widen between minor versions.
 - **Lexicon shapes** can change. Wire-compatible changes go through
   the [lexicon-evolution policy](../concepts/lexicon-evolution.md).
   Breaking changes ship with a derived migration lens.
@@ -24,18 +21,16 @@ Pre-1.0:
 - **HTTP routes** can change under the `v1` prefix between minor
   versions. After 1.0 they will not.
 
-## What does not change
+## Current commitments
 
 - The `dev.idiolect.*` namespace stays as is. NSID renames are
   possible but extraordinarily unusual. One would ship with a
   deprecation note in `dev.idiolect.dialect#deprecations`.
-- Records that pass validation continue to pass validation. A
-  record valid against v0.7's lexicon is also valid against v0.8's
-  (the new fields are optional).
-- The architectural commitments listed in the README do not
-  change between minor versions: records are signed and
-  content-addressed, lenses obey their stated laws, the lexicons
-  are the single source of truth, the codegen drift gate is on.
+- A breaking lexicon revision follows the evolution policy and should
+  ship with a migration lens. This process does not guarantee that an
+  older record validates unchanged against every later minor release.
+- Generated Rust and TypeScript remain derived from the checked-in
+  lexicons, and `idiolect-codegen --check` verifies that relationship.
 
 ## What changes at 1.0
 
@@ -49,9 +44,7 @@ Pre-1.0:
   `idiolect-indexer`, and `idiolect-orchestrator` become
   semver-stable.
 
-The 1.0 release date is not committed. The pre-1.0 series
-deliberately churns to find the right shape. 1.0 ships when the
-shape stops moving.
+The project has not committed to a 1.0 release date.
 
 ## Reading the changelog
 
@@ -78,6 +71,7 @@ The Changelog is in
 | --- | --- | --- |
 | `idiolect-records` | crates.io | exact version |
 | `@idiolect-dev/schema` | npm | exact version |
+| panproto crates | Git tag | `v0.70.1` for idiolect 0.11.1 |
 | `idiolect` CLI | binary release on GitHub | release tag |
 | `idiolect-orchestrator` container | `ghcr.io/idiolect-dev/orchestrator` | image SHA |
 | `idiolect-observer` container | `ghcr.io/idiolect-dev/observer` | image SHA |

--- a/docs/book/src/tutorial/01-install.md
+++ b/docs/book/src/tutorial/01-install.md
@@ -22,7 +22,7 @@ idiolect version
 ```
 
 ```text
-idiolect 0.11.1
+idiolect 0.12.0
 ```
 
 ## Resolve the project account

--- a/docs/book/src/tutorial/01-install.md
+++ b/docs/book/src/tutorial/01-install.md
@@ -1,96 +1,57 @@
-# Install and resolve a record
+# Install the CLI and fetch a lens
 
-The fastest way to get a working idiolect setup is to install the
-CLI from source. The CLI links against the same library crates an
-application would, so installing it also gives you the runtime
-machinery for later chapters.
+This chapter gets you from a fresh checkout to a live idiolect record in about
+five minutes. You need Git, Rust 1.95 or later, and a network connection. You do
+not need an ATProto account.
 
-## Install the CLI
+## Install from the checkout
+
+Clone the repository and install the command-line interface (CLI):
 
 ```bash
 git clone https://github.com/idiolect-dev/idiolect
 cd idiolect
-cargo install --path crates/idiolect-cli
+cargo install --locked --path crates/idiolect-cli
 ```
 
-This compiles every crate the CLI depends on (`idiolect-records`,
-`idiolect-identity`, `idiolect-lens`, plus their atproto transport
-features) and drops an `idiolect` binary into `~/.cargo/bin`. The
-build takes two to four minutes on a recent laptop. There is no
-runtime dependency on the cloned tree after install. You can `cd`
-anywhere.
-
-Confirm it works:
+The first build may take a few minutes. Confirm that the installed binary comes
+from this checkout:
 
 ```bash
 idiolect version
 ```
 
 ```text
-idiolect 0.8.0
+idiolect 0.11.1
 ```
 
-## Resolve a DID
+## Resolve the project account
 
-The first thing the runtime does on any record fetch is resolve a
-DID to its PDS. `idiolect resolve` exposes that step on its own:
-
-The project's own DID is a good first target:
+A [decentralized identifier (DID)](../glossary.md#did "Decentralized identifier")
+names an account. Its DID document identifies the account's
+[personal data server (PDS)](../glossary.md#pds "Personal data server"). Resolve
+the idiolect project DID:
 
 ```bash
 idiolect resolve did:plc:wdl4nnvxxdy4mc5vddxlm6f3
 ```
 
-```json
-{
-  "did": "did:plc:wdl4nnvxxdy4mc5vddxlm6f3",
-  "method": "Plc",
-  "handle": "idiolect.dev",
-  "pds_url": "https://jellybaby.us-east.host.bsky.network",
-  "also_known_as": ["at://idiolect.dev"]
-}
-```
+The JSON response should identify `idiolect.dev` and include a `pds_url`.
+Resolution is a separate step because records move with an account when its PDS
+changes.
 
-The resolver uses
-[`idiolect-identity`](../reference/crates/idiolect-identity.md)'s
-`ReqwestIdentityResolver`. For `did:plc:*` it goes through
-`plc.directory`; for `did:web:*` it fetches
-`https://<host>/.well-known/did.json`. Both transports are built
-on `reqwest`.
+## Fetch the tutorial lens
 
-If the DID does not resolve, the CLI prints a structured error
-on stderr (the message is `IdentityError`-shaped: the variant
-plus the underlying transport message).
-
-## Fetch a record
-
-`idiolect fetch` takes an at-uri and returns the raw record body
-(the `value` field of the xrpc response, not the response
-envelope). The project DID has a tutorial lens record published;
-fetching it exercises the runtime path end to end:
+An [AT-URI](../glossary.md#at-uri "AT Protocol record address") identifies one
+record by DID, collection, and record key. Fetch the published tutorial
+[lens](../glossary.md#lens "Bidirectional schema translation"):
 
 ```bash
 idiolect fetch \
   at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.lens/tutorial-rename-sort-string-to-text
 ```
 
-The response is a `dev.panproto.schema.lens` body carrying the
-protolens chain (`blob`), the source and target schema at-uris,
-the optic class (`iso`), and the content hash. Chapter 3 takes
-this exact record and runs it through `apply_lens`.
-
-The fetch goes through the same `PdsClient` impl `apply_lens`
-uses, so any record you can fetch this way you can also feed
-into the lens runtime.
-
-## Where things are stored
-
-| Artifact | Location |
-| --- | --- |
-| The `idiolect` binary | `~/.cargo/bin/idiolect` |
-| Cached crate sources | `~/.cargo/registry/src/` |
-| Cached PLC responses | `~/.cache/idiolect/plc/` (only if you set `IDIOLECT_CACHE_DIR`) |
-
-You do not need to wire any of this up by hand. The next chapter
-takes the raw json `idiolect fetch` returned and validates it
-against the shipped lexicon.
+The result is a real `dev.panproto.schema.lens` record. Its `sourceSchema` and
+`targetSchema` fields identify the schemas it connects, while `blob` contains
+the Panproto lens definition. Keep the checkout: the next chapter validates a
+typed record with the same libraries the CLI uses.

--- a/docs/book/src/tutorial/02-validate.md
+++ b/docs/book/src/tutorial/02-validate.md
@@ -1,160 +1,53 @@
-# Validate against the lexicon
+# Validate a typed record
 
-Every `dev.idiolect.*` lexicon ships in two forms: the JSON document
-under `lexicons/dev/idiolect/` and a generated Rust type under
-[`idiolect_records::generated`](../reference/crates/idiolect-records.md).
-The generated type carries serde codecs that fail closed: a record
-that does not match the lexicon will not deserialize.
+The record fetched in Chapter 1 came from the network. We now use a bundled
+fixture so that validation has a stable input and a reproducible result.
 
-## Add the records crate
+An ATProto [lexicon](../glossary.md#lexicon "AT Protocol schema document") defines
+a record's fields and constraints. `idiolect-records` generates a Rust type for
+each `dev.idiolect.*` lexicon and dispatches incoming JSON by its
+[namespaced identifier (NSID)](../glossary.md#nsid "Namespaced identifier").
 
-```bash
-cargo new --lib idiolect-tutorial
-cd idiolect-tutorial
-cargo add idiolect-records anyhow serde_json tokio --features tokio/macros,tokio/rt
-```
+## Run the valid case
 
-`idiolect-records` is a small crate (no transport dependencies). It
-exports one Rust type per record kind plus the
-[`Record`](../reference/crates/idiolect-records.md) trait.
-
-## Decode a record by NSID
-
-The crate ships minimally-valid fixtures for every record kind
-under `idiolect_records::examples`. They are real records: same
-shape the codec emits for a wire-format publish, same
-constraints, same `Record` impl. Use them to exercise the
-decode path without depending on what's on the network.
-
-In `src/main.rs`:
-
-```rust
-use idiolect_records::{decode_record, examples, AnyRecord, Dialect, Record};
-
-fn main() -> anyhow::Result<()> {
-    // The fixture is a typed value; serialise it back to JSON
-    // and decode through the dispatcher to exercise the same
-    // path a firehose handler would take.
-    let dialect = examples::dialect();
-    let value = serde_json::to_value(&dialect)?;
-
-    let rec = decode_record(&Dialect::nsid(), value)?;
-
-    match rec {
-        AnyRecord::Dialect(d) => println!(
-            "{}: {} idiolects, {} preferred lenses",
-            d.name,
-            d.idiolects.as_ref().map_or(0, |v| v.len()),
-            d.preferred_lenses.as_ref().map_or(0, |v| v.len()),
-        ),
-        other => anyhow::bail!(
-            "expected a dialect, got {}",
-            other.nsid_str(),
-        ),
-    }
-    Ok(())
-}
-```
-
-Run it:
+From the repository root, run the tutorial validator:
 
 ```bash
-cargo run
+cargo run --quiet \
+  --manifest-path scripts/publish-tutorial-lens/Cargo.toml \
+  --bin validate-tutorial-record
 ```
 
 ```text
-ud-en-2026: 0 idiolects, 0 preferred lenses
+validated dev.idiolect.dialect: ud-en-2026
 ```
 
-`decode_record` is the dispatch primitive: it takes an NSID and
-a JSON value, looks up the matching `Record` impl, and hands
-back an `AnyRecord`. If the JSON does not match the schema, it
-returns an error pointing at the first invalid field.
-
-The same path works for a JSON file fetched from a PDS, once
-some party publishes a `dev.idiolect.dialect` record on the
-network: read the bytes from disk (or from the
-`com.atproto.repo.getRecord` body), parse as
-`serde_json::Value`, hand to `decode_record`. The fixture
-shortcut is just a way to make this chapter not depend on
-network state.
-
-## Validation is structural, not just type-shaped
-
-The generated codecs validate every constraint declared in the
-lexicon, not just the field types:
-
-- `maxLength` and `maxGraphemes` on strings.
-- `format` constraints (`at-uri`, `did`, `nsid`, `datetime`,
-  `language`, `cid-link`).
-- `knownValues` for open enums (the value is preserved verbatim, but
-  the codec records whether it was a known slug or fell through to
-  `Other(String)` so consumers can decide).
-- `required` arrays.
-- `union` discriminator tags via `$type`.
-
-A record that violates one of these surfaces as a deserialization
-error with a `serde_path_to_error`-shaped path:
+The executable serializes the bundled `Dialect` fixture to JSON and sends it
+through the runtime dispatcher:
 
 ```text
-Error: dialect.entries[0].nsid: invalid format `at-uri`: missing scheme
+let value = serde_json::to_value(examples::dialect())?;
+let record = decode_record(&Dialect::nsid(), value)?;
 ```
 
-The boundary is exactly where you want it: at the parse, before any
-business logic touches the value.
+`Dialect::nsid()` selects the generated type. Deserialization then checks the
+required fields and the field formats represented by that type. The returned
+`AnyRecord::Dialect` value is safe to pass to code that expects a typed dialect.
 
-## Map of the family
+## See a rejection
 
-The generated tree mirrors the lexicons one-to-one. As of v0.8.0:
+The same executable can remove the required `createdAt` field before decoding:
 
-| Record | Module | NSID |
-| --- | --- | --- |
-| `Adapter` | `adapter` | `dev.idiolect.adapter` |
-| `Belief` | `belief` | `dev.idiolect.belief` |
-| `Bounty` | `bounty` | `dev.idiolect.bounty` |
-| `Community` | `community` | `dev.idiolect.community` |
-| `Correction` | `correction` | `dev.idiolect.correction` |
-| `Deliberation` | `deliberation` | `dev.idiolect.deliberation` |
-| `DeliberationStatement` | `deliberation_statement` | `dev.idiolect.deliberationStatement` |
-| `DeliberationVote` | `deliberation_vote` | `dev.idiolect.deliberationVote` |
-| `DeliberationOutcome` | `deliberation_outcome` | `dev.idiolect.deliberationOutcome` |
-| `Dialect` | `dialect` | `dev.idiolect.dialect` |
-| `Encounter` | `encounter` | `dev.idiolect.encounter` |
-| `Observation` | `observation` | `dev.idiolect.observation` |
-| `Recommendation` | `recommendation` | `dev.idiolect.recommendation` |
-| `Retrospection` | `retrospection` | `dev.idiolect.retrospection` |
-| `Verification` | `verification` | `dev.idiolect.verification` |
-| `Vocab` | `vocab` | `dev.idiolect.vocab` |
-
-Fixtures are exported under `idiolect_records::examples::*` for
-every record kind except the four deliberation lexicons, which
-are recent additions still awaiting bundled fixtures. The
-shipped fixtures are minimally-valid: every required field is
-present and the codec round-trip is a no-op.
-
-## Reusable trait surface
-
-Anything you write that consumes records can be generic over the
-`Record` trait:
-
-```rust
-use idiolect_records::Record;
-
-fn describe<R: Record>() -> String {
-    format!("{} record (NSID: {})", R::kind(), R::NSID)
-}
+```bash
+cargo run --quiet \
+  --manifest-path scripts/publish-tutorial-lens/Cargo.toml \
+  --bin validate-tutorial-record -- --invalid
 ```
 
-`R::kind()` returns the short kind name (`"encounter"`,
-`"recommendation"`, ...) and `R::NSID` is the fully-qualified
-NSID constant. `Record` does not carry instance-level methods on
-the record body itself. The at-uri at which a record lives is
-external (a `(did, collection, rkey)` triple from the firehose
-or PDS response).
+```text
+rejected invalid dev.idiolect.dialect record: record deserialization failed: missing field `createdAt`
+```
 
-The same trait is what the indexer (chapter on
-[indexing a firehose](../guide/index-firehose.md)) uses to
-filter out-of-family commits before decode.
-
-The next chapter takes a record we trust and runs it through a
-panproto lens.
+Validation occurs here: malformed JSON is rejected before application logic
+receives a record. Chapter 3 applies the live lens from Chapter 1 to a small
+source record.

--- a/docs/book/src/tutorial/03-apply-lens.md
+++ b/docs/book/src/tutorial/03-apply-lens.md
@@ -1,157 +1,68 @@
-# Apply a lens
+# Apply the lens
 
-A lens is a structure-preserving translation between two schemas.
-On the wire it is a `dev.panproto.schema.lens` record (re-exported
-by `idiolect-records` as `PanprotoLens`); at runtime it is a
-`panproto_lens::Lens` instantiated against a `Schema` graph.
-[`idiolect-lens`](../reference/crates/idiolect-lens.md) bridges the
-two: it resolves a lens record by at-uri, loads both schemas, and
-runs the lens.
+A [lens](../glossary.md#lens "Bidirectional schema translation") translates a
+record between two schemas. Its forward operation, `get`, returns the target
+record and a [complement](../glossary.md#complement "Data retained for put") that
+retains any source information needed by the reverse operation, `put`.
 
-## What a lens does
+This chapter applies the lens fetched in Chapter 1 to the following source
+record:
 
-A lens has a forward direction and a backward direction:
-
-$$
-\get : A \to (B, \complement) \qquad \put : (B, \complement) \to A
-$$
-
-`get` translates a source record `A` into a target view `B` plus a
-**complement** $\complement$ (the data that the projection
-discarded). `put` reconstructs `A` from a (possibly modified) `B`
-and the complement. The two directions obey the GetPut and PutGet
-laws covered in [Lens semantics and laws](../concepts/lens-laws.md).
-
-## Wire it up
-
-`idiolect-lens` is `publish = false`. Depend on it via git (or a
-path, when working inside the workspace):
-
-```toml
-# in Cargo.toml
-idiolect-lens   = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0", features = ["pds-reqwest"] }
-panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.39.0" }
-tokio           = { version = "1", features = ["full"] }
-```
-
-The lens runtime needs three pieces: a `Resolver` (fetches the
-lens record by at-uri), a `SchemaLoader` (turns the
-`dev.panproto.schema.schema` at-uris on the lens record into
-typed `panproto_schema::Schema` values), and a `Protocol`. v0.9
-ships `PdsSchemaLoader` to pair with `PdsResolver`; both share a
-`ReqwestPdsClient`.
-
-`src/main.rs`:
-
-```rust
-use idiolect_lens::{
-    apply_lens, ApplyLensInput, AtUri, PdsResolver, PdsSchemaLoader,
-    ReqwestPdsClient,
-};
-use panproto_schema::Protocol;
-
-const PDS:  &str = "https://jellybaby.us-east.host.bsky.network";
-const LENS: &str = "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.lens/tutorial-rename-sort-string-to-text";
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let client   = ReqwestPdsClient::with_service_url(PDS);
-    let resolver = PdsResolver::new(client.clone());
-    let loader   = PdsSchemaLoader::new(client);
-    let protocol = Protocol::default();
-
-    let lens_uri = AtUri::parse(LENS)?;
-    let source_record: serde_json::Value =
-        serde_json::from_str(r#"{ "text": "hello, world" }"#)?;
-
-    let out = apply_lens(&resolver, &loader, &protocol, ApplyLensInput {
-        lens_uri, source_record, source_root_vertex: None,
-    }).await?;
-
-    println!("{}", serde_json::to_string_pretty(&out.target_record)?);
-    Ok(())
-}
-```
-
-Run it:
-
-```bash
-cargo run
-```
-
-```text
+```json
 {
   "text": "hello, world"
 }
 ```
 
-The lens referenced above is real. The project DID has the
-three records the runtime needs to resolve it published on its
-PDS:
+## Confirm the Panproto version
 
-- `dev.panproto.schema.schema/tutorial-post-body-v1` — a
-  single-field "post:body" record with a string `text` child.
-- `dev.panproto.schema.schema/tutorial-post-body-v2` — the same
-  shape with the kind relabelled to `text`.
-- `dev.panproto.schema.lens/tutorial-rename-sort-string-to-text`
-  — a single-step `rename_sort` chain. The optic class is
-  `Iso`, and round-trip is byte-equal.
+The runnable package pins the Panproto crates used here to 0.70.1:
 
-`apply_lens` is one async call. It does five things in order:
+```toml
+panproto-lens   = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+```
 
-1. Resolve the lens record from the PDS via `PdsResolver`.
-2. Load the source and target schemas from the schema loader.
-3. Instantiate the protolens (or protolens chain) against the source
-   schema under the given protocol.
-4. Parse `source_record` into a panproto w-type instance, project it
-   through `get`, and serialize the view back to JSON under the
-   target schema.
-5. Return the target record together with the complement.
+The idiolect workspace uses the same Panproto version.
 
-The complement is a typed `panproto_lens::Complement`. Treat it
-as an opaque token: store it next to the target view, hand it
-back to `apply_lens_put` when you want to run the reverse
-direction, do not edit it.
+## Run `get`
 
-## Reverse the direction
+From the repository root, run the supplied client:
 
-```rust
-use idiolect_lens::{apply_lens_put, ApplyLensPutInput};
+```bash
+cargo run --quiet \
+  --manifest-path scripts/publish-tutorial-lens/Cargo.toml \
+  --bin apply-tutorial-lens
+```
 
-let back = apply_lens_put(
+```text
+target_record = {
+  "text": "hello, world"
+}
+```
+
+The executable creates one HTTP client, gives it to the lens and schema
+resolvers, and calls `apply_lens`:
+
+```text
+let out = apply_lens(
     &resolver,
     &loader,
     &protocol,
-    ApplyLensPutInput {
-        lens_uri: lens_uri.clone(),
-        target_record: out.target_record,
-        complement: out.complement,
-        target_root_vertex: None,
+    ApplyLensInput {
+        lens_uri,
+        source_record,
+        source_root_vertex: None,
     },
 )
 .await?;
-
-assert_eq!(back.source_record, source_record);
 ```
 
-If the lens is an isomorphism, `put(get(a))` returns the original
-`a` byte-for-byte. If it is a projection (information was dropped on
-the way through), `put` reconstructs `a` from the target plus the
-complement. If you modify the target between the calls, `put`
-applies the modification on top of the original source.
+The JSON value is unchanged because this tutorial lens renames a schema sort
+from `string` to `text`; it does not rename the record's `text` field. The
+unchanged value records a successful run: the runtime resolved the lens, loaded
+both schemas, instantiated Panproto 0.70.1, and produced a target-schema value.
 
-## What can go wrong
-
-| Symptom | Cause |
-| --- | --- |
-| `LensError::NotFound` | The lens at-uri did not resolve. Check the DID and the rkey. |
-| `LensError::LexiconParse` | The schema loader returned bytes that were not a valid panproto schema. |
-| `LensError::Translate` | The source record did not parse as an instance of the source schema. |
-| Output complement is huge | The lens is closer to a projection than you thought. See [Lens semantics](../concepts/lens-laws.md). |
-
-The runtime is `Send`-clean. You can hold an `Arc<dyn Resolver>` and
-call `apply_lens` from inside an `#[async_trait]` handler in an
-HTTP server.
-
-The next chapter takes that lens and runs a verification against
-it.
+The returned `out.complement` belongs with this application of the lens.
+Passing it to `apply_lens_put` would reconstruct the source record. Chapter 4
+checks that reconstruction over several inputs.

--- a/docs/book/src/tutorial/03-apply-lens.md
+++ b/docs/book/src/tutorial/03-apply-lens.md
@@ -16,11 +16,11 @@ record:
 
 ## Confirm the Panproto version
 
-The runnable package pins the Panproto crates used here to 0.70.1:
+The runnable package pins the Panproto crates used here to 0.71.0:
 
 ```toml
-panproto-lens   = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-lens   = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
 ```
 
 The idiolect workspace uses the same Panproto version.
@@ -61,7 +61,7 @@ let out = apply_lens(
 The JSON value is unchanged because this tutorial lens renames a schema sort
 from `string` to `text`; it does not rename the record's `text` field. The
 unchanged value records a successful run: the runtime resolved the lens, loaded
-both schemas, instantiated Panproto 0.70.1, and produced a target-schema value.
+both schemas, instantiated Panproto 0.71.0, and produced a target-schema value.
 
 The returned `out.complement` belongs with this application of the lens.
 Passing it to `apply_lens_put` would reconstruct the source record. Chapter 4

--- a/docs/book/src/tutorial/04-verify.md
+++ b/docs/book/src/tutorial/04-verify.md
@@ -18,7 +18,7 @@ cargo run --quiet \
 ```text
 result = Holds
 kind   = RoundtripTest
-tool   = idiolect-verify/roundtrip-test 0.11.1
+tool   = idiolect-verify/roundtrip-test 0.12.0
 ```
 
 The executable gives the corpus to `RoundtripTestRunner` and runs it against

--- a/docs/book/src/tutorial/04-verify.md
+++ b/docs/book/src/tutorial/04-verify.md
@@ -1,160 +1,51 @@
-# Run a verification
+# Verify the round trip
 
-A `dev.idiolect.verification` record is a signed claim that a lens
-satisfies a property. The verifier crate
-([`idiolect-verify`](../reference/crates/idiolect-verify.md))
-ships four runner kinds:
+A [verification](../glossary.md#verification "Claim about a lens property") is a
+typed claim about a lens property. Here we test whether `put(get(source))`
+returns `source` for three records: ordinary text, an empty string, and Unicode
+text.
 
-- **`roundtrip-test`** runs `put(get(a)) == a` over a corpus of
-  source records.
-- **`property-test`** runs an arbitrary boolean predicate over a
-  corpus, suitable for laws beyond round-trip (idempotence,
-  commutativity, naturality, ...).
-- **`static-check`** runs panproto's existence and structural
-  checks against the lens chain.
-- **`coercion-law`** runs panproto's sample-based coercion-law
-  checker against any `CoerceType` step.
+## Run the verifier
 
-Each ships as a struct implementing `VerificationRunner`. The
-crate is library-only; runners are invoked programmatically.
-
-## Wire up a runner
-
-```toml
-# in Cargo.toml
-idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0" }
-idiolect-lens   = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0", features = ["pds-reqwest"] }
-idiolect-records = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0" }
-panproto-schema  = { git = "https://github.com/panproto/panproto.git", tag = "v0.47.0" }
-tokio            = { version = "1", features = ["full"] }
-```
-
-`src/main.rs`:
-
-```rust
-use idiolect_lens::{PdsResolver, PdsSchemaLoader, ReqwestPdsClient};
-use idiolect_records::Datetime;
-use idiolect_records::generated::dev::idiolect::defs::LensRef;
-use idiolect_verify::{
-    RoundtripTestRunner, VerificationRunner, VerificationTarget,
-};
-use panproto_schema::Protocol;
-
-const PDS:      &str = "https://jellybaby.us-east.host.bsky.network";
-const LENS_URI: &str = "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.lens/tutorial-rename-sort-string-to-text";
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let client   = ReqwestPdsClient::with_service_url(PDS);
-    let resolver = PdsResolver::new(client.clone());
-    let loader   = PdsSchemaLoader::new(client);
-
-    // Small corpus matching the lens's source schema (single
-    // `text` string child on a `post:body` object).
-    let corpus = vec![
-        serde_json::json!({ "text": "hello, world" }),
-        serde_json::json!({ "text": "" }),
-        serde_json::json!({ "text": "líneas con tildes y emoji 🦀" }),
-    ];
-
-    let runner = RoundtripTestRunner::new(resolver, loader, Protocol::default(), corpus);
-
-    let target = VerificationTarget {
-        lens: LensRef {
-            uri: Some(LENS_URI.parse()?),
-            cid: None,
-            direction: None,
-        },
-        verifier: "did:plc:wdl4nnvxxdy4mc5vddxlm6f3".parse()?,
-        occurred_at: Datetime::parse("2026-05-12T00:00:00.000Z")?,
-        tool_override: None,
-    };
-
-    let verification = runner.run(&target).await?;
-    println!("result = {:?}", verification.result);
-    println!("kind   = {:?}", verification.kind);
-    println!("tool   = {} {}",
-             verification.tool.name, verification.tool.version);
-    Ok(())
-}
-```
+From the repository root:
 
 ```bash
-cargo run
+cargo run --quiet \
+  --manifest-path scripts/publish-tutorial-lens/Cargo.toml \
+  --bin verify-tutorial-lens
 ```
 
 ```text
 result = Holds
 kind   = RoundtripTest
-tool   = idiolect-verify/roundtrip-test 0.9.0
+tool   = idiolect-verify/roundtrip-test 0.11.1
 ```
 
-The runner walked the corpus, applied the rename-sort lens
-forward then backward, and confirmed every record round-tripped
-byte-for-byte. A single counterexample would have produced
-`result = Falsified`.
+The executable gives the corpus to `RoundtripTestRunner` and runs it against
+the published lens:
 
-## Falsified is a record, not an error
-
-A *falsified* property returns
-`Ok(Verification { result: Falsified, ... })`, not an error. A
-falsified verification is a normal result the runner exists to
-report. Treat it like a finding: sign it and publish it.
-Consumers reading the falsified record decide whether to continue
-invoking the lens.
-
-`VerifyError` is reserved for input-shape, transport, or
-irrecoverable-state failures (a corpus the runner could not load,
-a schema the loader could not resolve). Those are operator
-problems. The lens's actual behaviour is captured in the
-returned record.
-
-## Publish the result
-
-The `verification` value the runner returned is a typed
-`Verification` record ready to publish. The publishing path
-goes through `idiolect_lens::RecordPublisher`; see [chapter 5
-on publishing](./05-publish.md) for the wire-up.
-
-## Reading verifications back
-
-The orchestrator's HTTP API exposes
-`GET /v1/verifications?lens_uri=...` for "every verification on
-this lens":
-
-```bash
-idiolect orchestrator verifications \
-  --lens_uri at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.lens/tutorial-rename-sort-string-to-text
+```text
+let runner = RoundtripTestRunner::new(
+    resolver,
+    loader,
+    Protocol::default(),
+    corpus,
+);
+let verification = runner.run(&target).await?;
 ```
 
-The orchestrator reads its catalog (populated by the indexer)
-and returns the matching verification records. This is the
-shape downstream consumers use to decide whether to invoke a
-lens: query the verifier registry, accept the verifications they
-trust, reject the rest, and proceed only if the surviving set
-covers the properties their use case requires.
+For each source record, the runner calls `apply_lens` and then
+`apply_lens_put`. `Holds` means that all three records round-tripped exactly.
+It supports a claim about this corpus; it is not a proof over every possible
+record.
 
-## From the CLI
+## Distinguish a finding from a failure
 
-The library code above is also exposed as a CLI subcommand for
-quick operator runs. All four shipped runner kinds are wrapped:
+A counterexample produces a typed verification with `result = Falsified`.
+That finding is a successful verifier run and can be published. Transport,
+schema-loading, and malformed-input problems instead return `VerifyError`,
+because the runner could not evaluate the property.
 
-```bash
-idiolect verify roundtrip-test --lens at://.../tutorial-rename-sort-string-to-text
-idiolect verify property-test  --lens at://.../tutorial-rename-sort-string-to-text --corpus ./samples.jsonl
-idiolect verify static-check   --lens at://.../tutorial-rename-sort-string-to-text
-idiolect verify coercion-law   --lens at://... --vcs-url https://vcs.example --standard atproto-lexicon
-```
-
-The CLI prints the typed `Verification` record as JSON and
-exits non-zero on `Falsified` or `Inconclusive`, which makes it
-suitable for CI gates.
-
-Additional kinds in the lexicon's `verification.kind` enum
-(`formal-proof`, `conformance-test`, `convergence-preserving`)
-are recognised slugs awaiting community-contributed runners;
-authoring one is the
-[Author a verification runner](../guide/verify.md) loop.
-
-The next chapter publishes a `dev.idiolect.recommendation` that
-endorses a lens path under specific applicability conditions.
+The `verification` value is already shaped like a
+`dev.idiolect.verification` record. Chapter 5 publishes a recommendation that
+identifies the same lens and the source schema under which it applies.

--- a/docs/book/src/tutorial/05-publish.md
+++ b/docs/book/src/tutorial/05-publish.md
@@ -1,256 +1,63 @@
 # Publish a recommendation
 
-A `dev.idiolect.recommendation` is a community-published opinion
-that a particular lens path is appropriate under specific
-applicability conditions. Consumers query recommendations before
-choosing a translation. A lens nobody recommends is just code. A
-lens a community recommends, under conditions the consumer meets,
-is a routing decision.
+A [recommendation](../glossary.md#recommendation "Conditional lens endorsement")
+records that a community endorses a lens path under stated conditions. The
+tutorial publisher creates a small community record for your account, then
+publishes a recommendation whose `conditionSourceIs` points at the source
+schema used in Chapters 3 and 4.
 
-The shape is:
+This chapter writes two public records to your PDS. The earlier chapters were
+read-only.
+
+## Create an app password
+
+Use an ATProto account intended for this exercise. Create an app password in
+your account settings, then set the PDS URL, handle, and password in your
+shell. The example below uses Bluesky's hosted PDS; replace the URL if your
+account uses another server.
+
+```bash
+export PDS_URL='https://bsky.social'
+export ATPROTO_HANDLE='your-handle.bsky.social'
+export ATPROTO_PASSWORD='xxxx-xxxx-xxxx-xxxx'
+```
+
+Avoid placing a real password in a shared shell history. An app password can
+be revoked without changing the account's main password.
+
+## Publish both records
+
+From the repository root:
+
+```bash
+cargo run --quiet \
+  --manifest-path scripts/publish-tutorial-lens/Cargo.toml \
+  --bin publish-tutorial-recommendation
+unset ATPROTO_PASSWORD
+```
+
+The PDS assigns fresh record keys, so the command prints different
+[AT-URIs](../glossary.md#at-uri "AT Protocol record address") for each run:
 
 ```text
-issuingCommunity : at-uri        # the community publishing
-conditions       : [Condition]   # postfix applicability tree
-preconditions    : [Condition]   # additional assumptions
-lensPath         : [at-uri]      # one or more chained lenses
-caveats          : [Caveat]      # structured failure modes
-requiredVerifications : [LensProperty]
-occurredAt       : datetime
+community      at://did:plc:.../dev.idiolect.community/...
+recommendation at://did:plc:.../dev.idiolect.recommendation/...
 ```
 
-`conditions` and `preconditions` are postfix-operator trees over
-the combinator set defined inside
-[`dev.idiolect.recommendation`](../reference/lexicons/recommendation.md).
+The recommendation contains three load-bearing references: (i) the community
+record just published, (ii) the tutorial's source schema as its applicability
+condition, and (iii) the tutorial lens as its one-step lens path. The generated
+Rust types validate those fields before the publisher sends the record.
 
-## Author the record
+## Read the result back
 
-```toml
-idiolect-records = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.10.0" }
-reqwest          = { version = "0.12", features = ["json"] }
-serde            = { version = "1", features = ["derive"] }
-tokio            = { version = "1", features = ["full"] }
-```
-
-```rust
-use idiolect_records::generated::dev::idiolect::defs::{LensRef, SchemaRef};
-use idiolect_records::generated::dev::idiolect::recommendation::{
-    ConditionSourceIs, Recommendation, RecommendationConditions,
-};
-use idiolect_records::{Datetime, Record};
-
-const LENS_URI: &str = "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.lens/tutorial-rename-sort-string-to-text";
-const SRC_SCHEMA_URI: &str = "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.schema/tutorial-post-body-v1";
-
-fn build_recommendation(community_did: &str) -> anyhow::Result<Recommendation> {
-    let community = format!("at://{community_did}/dev.idiolect.community/canonical");
-    Ok(Recommendation {
-        issuing_community: community.parse()?,
-        conditions: vec![RecommendationConditions::ConditionSourceIs(
-            ConditionSourceIs {
-                schema: SchemaRef {
-                    cid: None,
-                    language: None,
-                    uri: Some(SRC_SCHEMA_URI.parse()?),
-                },
-            },
-        )],
-        preconditions: None,
-        lens_path: vec![LensRef {
-            uri: Some(LENS_URI.parse()?),
-            cid: None,
-            direction: None,
-        }],
-        caveats: None,
-        caveats_text: None,
-        annotations: Some(
-            "Endorses the rename-sort tutorial lens for source \
-             records matching the v1 tutorial post-body schema."
-                .to_owned(),
-        ),
-        required_verifications: None,
-        basis: None,
-        occurred_at: Datetime::parse("2026-05-12T00:00:00.000Z")?,
-        supersedes: None,
-    })
-}
-```
-
-Every required field is type-checked at construction. Optional
-fields are `Option<...>`. The open-enum slugs in `Condition*`
-variants round-trip through their `*Vocab` siblings as covered
-in [Open enums and vocabularies](../concepts/open-enums.md).
-
-## Get an authenticated session
-
-The simplest auth path is an app password (legacy Bearer mode,
-not OAuth + DPoP). Generate one at
-<https://bsky.app/settings/app-passwords> for the account you
-want to publish under, then load it via env vars:
-
-```rust
-use serde::{Deserialize, Serialize};
-
-#[derive(Serialize)]
-struct CreateSessionRequest<'a> {
-    identifier: &'a str,
-    password: &'a str,
-}
-
-#[derive(Deserialize)]
-struct Session {
-    did: String,
-    #[serde(rename = "accessJwt")]
-    access_jwt: String,
-}
-
-async fn create_session(
-    http: &reqwest::Client,
-    pds: &str,
-    handle: &str,
-    password: &str,
-) -> anyhow::Result<Session> {
-    let resp = http
-        .post(format!("{pds}/xrpc/com.atproto.server.createSession"))
-        .json(&CreateSessionRequest { identifier: handle, password })
-        .send().await?;
-    if !resp.status().is_success() {
-        anyhow::bail!("createSession {}: {}", resp.status(), resp.text().await?);
-    }
-    Ok(resp.json().await?)
-}
-```
-
-OAuth + DPoP is the recommended path for production. The
-machinery lives in `idiolect-lens` under the `dpop-p256` feature
-plus `idiolect-oauth`'s session stores. For tutorial purposes
-the Bearer path is enough.
-
-## Sign and publish
-
-The PDS accepts a typed record body plus a `$type` discriminator
-on a `com.atproto.repo.createRecord` call:
-
-```rust
-#[derive(Serialize)]
-struct CreateRecordRequest<'a> {
-    repo: &'a str,
-    collection: &'a str,
-    rkey: &'a str,
-    record: serde_json::Value,
-}
-
-async fn publish(
-    http: &reqwest::Client,
-    pds: &str,
-    bearer: &str,
-    repo: &str,
-    rec: &Recommendation,
-    rkey: &str,
-) -> anyhow::Result<()> {
-    let mut value = serde_json::to_value(rec)?;
-    if let serde_json::Value::Object(ref mut map) = value {
-        map.insert(
-            "$type".to_owned(),
-            serde_json::Value::String(Recommendation::NSID.to_owned()),
-        );
-    }
-    let resp = http
-        .post(format!("{pds}/xrpc/com.atproto.repo.createRecord"))
-        .bearer_auth(bearer)
-        .json(&CreateRecordRequest {
-            repo,
-            collection: Recommendation::NSID,
-            rkey,
-            record: value,
-        })
-        .send().await?;
-    if !resp.status().is_success() {
-        anyhow::bail!("createRecord {}: {}", resp.status(), resp.text().await?);
-    }
-    Ok(())
-}
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let pds      = std::env::var("PDS_URL")?;
-    let handle   = std::env::var("ATPROTO_HANDLE")?;
-    let password = std::env::var("ATPROTO_PASSWORD")?;
-
-    let http = reqwest::Client::new();
-    let sess = create_session(&http, &pds, &handle, &password).await?;
-    let rec  = build_recommendation(&sess.did)?;
-    publish(&http, &pds, &sess.access_jwt, &sess.did, &rec,
-            "tutorial-rename-sort").await?;
-    println!("published at://{}/{}/tutorial-rename-sort",
-             sess.did, Recommendation::NSID);
-    Ok(())
-}
-```
-
-Run with credentials in the env:
+Copy the printed recommendation AT-URI into the CLI:
 
 ```bash
-PDS_URL=https://bsky.social \
-ATPROTO_HANDLE=yourhandle.bsky.social \
-ATPROTO_PASSWORD='xxxx-xxxx-xxxx-xxxx' \
-cargo run
+idiolect fetch at://did:plc:.../dev.idiolect.recommendation/...
 ```
 
-The project DID has already published this exact record:
-
-```bash
-idiolect fetch \
-  at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.idiolect.recommendation/tutorial-rename-sort
-```
-
-If the record decodes and the `issuingCommunity` resolves to a
-community you control, the loop is closed:
-
-```mermaid
-flowchart LR
-    A[author] -->|publishes| R[recommendation]
-    R -->|points at| L[lens path]
-    L -->|verified by| V[verification records]
-    R -->|consumed by| C[consumer]
-    C -->|decides| I[invoke or not]
-```
-
-The community has expressed an opinion. The lens has
-machine-checkable verifications attached (chapter 4 produced
-`Holds` for the `roundtrip-test` property). A consumer querying
-the orchestrator can fetch both, evaluate the conditions, and
-decide whether to invoke.
-
-## From the CLI
-
-The CLI ships both pieces of this flow:
-
-```bash
-# 1. Authenticate (app password; legacy Bearer mode).
-idiolect oauth login --handle yourhandle.bsky.social
-# password from --app-password or env
-
-# 2. Publish a record from a JSON file.
-idiolect publish recommendation --record ./tutorial-rename-sort.json
-```
-
-`idiolect oauth login` exchanges credentials via
-`com.atproto.server.createSession` and stores the resulting
-session as a JSON file. `idiolect publish <kind>` validates the
-JSON against the typed `Record` impl, splices in `$type`, and
-POSTs `com.atproto.repo.createRecord` under the stored session.
-
-ATProto is moving off app passwords toward OAuth + DPoP; the
-next-iteration CLI wraps `atrium-oauth`'s browser-handoff dance
-and persists the resulting DPoP-bound session through the same
-`OAuthTokenStore`. The publish path is unchanged.
-
-That completes the loop. Where to go next:
-
-- [Run the orchestrator HTTP API](../guide/orchestrator.md)
-  shows how the consumer side of that flow is served.
-- [Author a community vocabulary](../guide/vocabulary.md) covers
-  the open-enum extension story.
-- The [Concepts](../concepts/index.md) section explains why this
-  loop is shaped the way it is.
+The returned JSON should contain `issuingCommunity`, `conditions`, `lensPath`,
+and `occurredAt`. This output confirms that the recommendation was published.
+Continue with [Publish a lens](../guide/publish-lens.md) when you need to author
+the schemas and lens rather than reuse the tutorial records.

--- a/docs/book/src/tutorial/index.md
+++ b/docs/book/src/tutorial/index.md
@@ -1,33 +1,27 @@
 # Tutorial
 
-This tutorial walks one example end to end. By the time you finish
-you will have:
+This tutorial follows one published Panproto lens from discovery to
+recommendation. The route is linear, and the first chapter produces a live,
+read-only result in about five minutes:
 
-1. installed the `idiolect` CLI and the `idiolect-records` /
-   `idiolect-lens` crates,
-2. fetched a real ATProto record and validated it against the
-   shipped lexicon,
-3. resolved a `dev.panproto.schema.lens` record and applied it to
-   translate a source record into a target record,
-4. run a verification runner against a lens and recorded the result,
-5. published a `dev.idiolect.recommendation` record from your own
-   PDS endorsing a lens path.
+1. [Install the CLI and fetch a lens](./01-install.md) from the idiolect project
+   account.
+2. [Validate a typed record](./02-validate.md) through the generated NSID
+   dispatcher.
+3. [Apply the lens](./03-apply-lens.md) to a small JSON record with Panproto
+   0.70.1.
+4. [Verify the round trip](./04-verify.md) over a three-record corpus.
+5. [Publish a recommendation](./05-publish.md) and its community record to your
+   [personal data server (PDS)](../glossary.md#pds "Personal data server").
 
-The chapters are linear. Each one starts from the state the previous
-one left behind. If you want a task-shaped reference instead, jump
-to the [Guides](../guide/index.md). If you want the underlying
-theory, the [Concepts](../concepts/index.md) section is the place.
+Each chapter starts from the repository state left by the previous one. The
+first four chapters do not require an ATProto account; Chapter 5 does, because
+it writes public records. Use the [Guides](../guide/index.md) for task-specific
+procedures and the [Concepts](../concepts/index.md) for the underlying model.
 
 ## Prerequisites
 
-You need:
-
-- Rust 1.95 or newer (`rustup default stable`).
-- Cargo, with network access to crates.io.
-- A working ATProto identity (a `did:plc:*` or `did:web:*`) for the
-  publishing chapter. If you do not have one, the bsky.app sign-up
-  flow gives you one. Most chapters work without it.
-- About 30 minutes of focused time.
-
-The rest of this tutorial assumes you are running commands from a
-fresh terminal at the root of a Cargo workspace you control.
+You need Git, Rust 1.95 or later, Cargo, and network access. Clone the idiolect
+repository in Chapter 1 and run the remaining commands from its root. If you
+plan to complete Chapter 5, you also need an ATProto account and an app
+password for that account.

--- a/docs/book/src/tutorial/index.md
+++ b/docs/book/src/tutorial/index.md
@@ -9,7 +9,7 @@ read-only result in about five minutes:
 2. [Validate a typed record](./02-validate.md) through the generated NSID
    dispatcher.
 3. [Apply the lens](./03-apply-lens.md) to a small JSON record with Panproto
-   0.70.1.
+   0.71.0.
 4. [Verify the round trip](./04-verify.md) over a three-record corpus.
 5. [Publish a recommendation](./05-publish.md) and its community record to your
    [personal data server (PDS)](../glossary.md#pds "Personal data server").

--- a/lexicons/dev/panproto/VENDORED.md
+++ b/lexicons/dev/panproto/VENDORED.md
@@ -6,8 +6,8 @@ Do not edit them in place — update the pin below and re-vendor.
 | field           | value                                      |
 |-----------------|--------------------------------------------|
 | upstream        | `panproto/panproto` (git)                  |
-| commit          | `02158abb80252378a21bb1a9bee839d053a21795` |
-| workspace ver.  | `0.39.0`                                   |
+| commit          | `ee2f52d52e372e2ef771801d67c6b4469e165e1e` |
+| workspace ver.  | `0.70.1`                                   |
 | source path     | `lexicons/dev/panproto/`                   |
 
 ## Vendored set
@@ -35,8 +35,8 @@ Procedures / queries (`translate/applyLens.json`, `schema/findLenses.json`,
 implements, not storage records; they live in upstream panproto and aren't
 regenerated here.
 
-Out-of-scope-for-now record types (`editLens`, `symmetricLens`, `theory`,
-`theoryMorphism`, `protocol`, `migration`, `expr`) can be vendored when a
+Out-of-scope-for-now record types (`editLens`, `symmetricLens`,
+`theoryMorphism`, `migration`, `expr`) can be vendored when a
 downstream feature needs them; the vendor step is mechanical.
 
 ## How to refresh
@@ -44,4 +44,8 @@ downstream feature needs them; the vendor step is mechanical.
 1. bump the commit in this file.
 2. `cp` the new upstream `.json` files over the ones listed above.
 3. `cargo run -p idiolect-codegen` to regenerate the typed bindings.
-4. `cargo test` + `pnpm test` to confirm no downstream break.
+4. `cargo test` + `bun test` to confirm no downstream break.
+
+The files listed above were compared byte for byte with commit
+`ee2f52d52e372e2ef771801d67c6b4469e165e1e`; no file contents changed during
+the 0.70.1 refresh.

--- a/lexicons/dev/panproto/VENDORED.md
+++ b/lexicons/dev/panproto/VENDORED.md
@@ -1,13 +1,15 @@
 # Vendored `dev.panproto.*` lexicons
 
-These `.json` files are verbatim copies of upstream panproto lexicons.
-Do not edit them in place — update the pin below and re-vendor.
+The `schema/` and `vcs/` `.json` files listed below are verbatim copies of
+upstream panproto lexicons. Do not edit them in place — update the pin below
+and re-vendor. The `examples/` directory contains local fixture records and is
+not part of the upstream vendored subset.
 
 | field           | value                                      |
 |-----------------|--------------------------------------------|
 | upstream        | `panproto/panproto` (git)                  |
-| commit          | `ee2f52d52e372e2ef771801d67c6b4469e165e1e` |
-| workspace ver.  | `0.70.1`                                   |
+| commit          | `efa04235eb9aa9d718ad358b6104f69eac17881f` |
+| workspace ver.  | `0.71.0`                                   |
 | source path     | `lexicons/dev/panproto/`                   |
 
 ## Vendored set
@@ -46,6 +48,6 @@ downstream feature needs them; the vendor step is mechanical.
 3. `cargo run -p idiolect-codegen` to regenerate the typed bindings.
 4. `cargo test` + `bun test` to confirm no downstream break.
 
-The files listed above were compared byte for byte with commit
-`ee2f52d52e372e2ef771801d67c6b4469e165e1e`; no file contents changed during
-the 0.70.1 refresh.
+The upstream files listed above were compared byte for byte with commit
+`efa04235eb9aa9d718ad358b6104f69eac17881f`; no vendored Lexicon contents
+changed during the 0.71.0 refresh.

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.3.0",
+    "jsdom": "26.1.0",
     "typescript": "5.7.3"
   }
 }

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.11.1",
+  "version": "0.12.0",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",

--- a/scripts/check_book.py
+++ b/scripts/check_book.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Run deterministic structural checks over the mdBook source."""
+
+from __future__ import annotations
+
+import argparse
+import collections
+import json
+import re
+import shlex
+import subprocess
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import unquote
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOK = ROOT / "docs" / "book" / "src"
+
+
+@dataclass(frozen=True)
+class Fence:
+    path: Path
+    line: int
+    info: str
+    body: str
+
+    @property
+    def language(self) -> str:
+        return self.info.split(",", 1)[0].split(None, 1)[0].lower()
+
+
+BANNED = (
+    r"\bdelve\b",
+    r"\btapestry\b",
+    r"\brealm\b",
+    r"\blandscape\b",
+    r"\bseamless(?:ly)?\b",
+    r"\bpivotal\b",
+    r"\bnuanced\b",
+    r"\bharness(?: the power)?\b",
+    r"\bfoster\b",
+    r"\bunderscore(?:s|d|ing)?(?: the importance)?\b",
+    r"\bshed(?:s|ding)? light on\b",
+    r"\bmyriad\b",
+    r"\bplethora\b",
+    r"\bmultifaceted\b",
+    r"\bcutting-edge\b",
+    r"\bgame-changer\b",
+    r"\butili[sz]e(?:s|d|ing)?\b",
+    r"\bit(?:'s| is) (?:worth|important) to note\b",
+    r"\bthis section explores\b",
+    r"\bthis distinction matters\b",
+    r"\bnavigate the complexities\b",
+    r"\bpav(?:e|es|ed|ing) the way\b",
+    r"\btestament to\b",
+    r"\btreasure trove\b",
+    r"\bin today's world\b",
+    r"\bever-evolving\b",
+    r"\bwithout a doubt\b",
+    r"\bit goes without saying\b",
+    r"\bclearly\b",
+    r"\bobviously\b",
+    r"\bundoubtedly\b",
+)
+
+BRITISH = {
+    "behaviour": "behavior",
+    "behaviours": "behaviors",
+    "catalogue": "catalog",
+    "catalogues": "catalogs",
+    "colour": "color",
+    "colours": "colors",
+    "factorisation": "factorization",
+    "fibre": "fiber",
+    "fibres": "fibers",
+    "judgement": "judgment",
+    "judgements": "judgments",
+    "labelled": "labeled",
+    "materialised": "materialized",
+    "modelled": "modeled",
+    "neighbour": "neighbor",
+    "neighbours": "neighbors",
+    "normalised": "normalized",
+    "optimisation": "optimization",
+    "optimisations": "optimizations",
+    "organisation": "organization",
+    "organisations": "organizations",
+    "parameterised": "parameterized",
+    "pluralised": "pluralized",
+    "recognised": "recognized",
+    "serialised": "serialized",
+    "summarising": "summarizing",
+}
+
+
+def display(path: Path) -> str:
+    return str(path.relative_to(ROOT))
+
+
+def extract_fences(path: Path, text: str, errors: list[str]) -> list[Fence]:
+    fences: list[Fence] = []
+    open_line: int | None = None
+    info = ""
+    body: list[str] = []
+    for number, line in enumerate(text.splitlines(), 1):
+        if line.startswith("```"):
+            if open_line is None:
+                open_line = number
+                info = line[3:].strip()
+                body = []
+            elif line.strip() == "```":
+                fences.append(Fence(path, open_line, info, "\n".join(body) + "\n"))
+                open_line = None
+                info = ""
+                body = []
+            else:
+                body.append(line)
+        elif open_line is not None:
+            body.append(line)
+    if open_line is not None:
+        errors.append(f"{display(path)}:{open_line}: unclosed code fence")
+    return fences
+
+
+def prose_without_code(text: str) -> str:
+    text = re.sub(r"^```.*?^```\s*$", "", text, flags=re.MULTILINE | re.DOTALL)
+    text = re.sub(r"`[^`\n]+`", "", text)
+    text = re.sub(r"https?://\S+", "", text)
+    return text
+
+
+def slugify(heading: str) -> str:
+    heading = re.sub(r"!?(?:\[([^]]+)\])\([^)]+\)", r"\1", heading)
+    heading = re.sub(r"[`*_~]", "", heading).strip().lower()
+    heading = re.sub(r"[^\w\- ]", "", heading)
+    return re.sub(r"[ ]+", "-", heading)
+
+
+def anchors(path: Path, text: str) -> set[str]:
+    result = {
+        slugify(match.group(1))
+        for match in re.finditer(r"^#{1,6}\s+(.+?)\s*#*\s*$", text, re.MULTILINE)
+    }
+    result.update(re.findall(r"<(?:a|span)\s+(?:name|id)=[\"']([^\"']+)", text))
+    return result
+
+
+def validate_link(
+    source: Path,
+    raw_destination: str,
+    anchor_map: dict[Path, set[str]],
+    errors: list[str],
+) -> None:
+    try:
+        parts = shlex.split(raw_destination)
+    except ValueError as exc:
+        errors.append(f"{display(source)}: malformed link destination {raw_destination!r}: {exc}")
+        return
+    if not parts:
+        return
+    destination = unquote(parts[0].strip("<>"))
+    if re.match(r"^(?:https?|mailto|tel):", destination) or destination.startswith("/"):
+        return
+    target_part, _, fragment = destination.partition("#")
+    target = source if not target_part else (source.parent / target_part).resolve()
+    if target.suffix == ".html":
+        target = target.with_suffix(".md")
+    if target.is_dir():
+        target /= "index.md"
+    if not target.exists():
+        errors.append(f"{display(source)}: missing local link target {destination!r}")
+        return
+    if fragment and target.suffix == ".md" and fragment not in anchor_map.get(target, set()):
+        errors.append(
+            f"{display(source)}: missing anchor #{fragment} in {display(target)}"
+        )
+
+
+def validate_fence(fence: Fence, errors: list[str]) -> None:
+    label = f"{display(fence.path)}:{fence.line}"
+    language = fence.language
+    if language == "rust" and "ignore" in {
+        flag.strip() for flag in fence.info.split(",")[1:]
+    }:
+        errors.append(f"{label}: rust,ignore is prohibited")
+    try:
+        if language == "json":
+            json.loads(fence.body)
+        elif language == "toml":
+            tomllib.loads(fence.body)
+        elif language in {"bash", "sh", "shell"}:
+            completed = subprocess.run(
+                ["bash", "-n"],
+                input=fence.body,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            if completed.returncode:
+                raise ValueError(completed.stderr.strip())
+        elif language == "python":
+            compile(fence.body, label, "exec")
+        elif language in {"yaml", "yml"}:
+            try:
+                import yaml  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise ValueError("PyYAML is required to validate YAML fences") from exc
+            yaml.safe_load(fence.body)
+    except (ValueError, json.JSONDecodeError, tomllib.TOMLDecodeError, SyntaxError) as exc:
+        errors.append(f"{label}: invalid {language} fence: {exc}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--require-no-rust",
+        action="store_true",
+        help="fail when a Rust fence remains outside the compiled-example harness",
+    )
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    markdown = sorted(BOOK.rglob("*.md"))
+    texts = {path.resolve(): path.read_text(encoding="utf-8") for path in markdown}
+    anchor_map = {path: anchors(path, text) for path, text in texts.items()}
+    fences: list[Fence] = []
+
+    for path, text in texts.items():
+        file_fences = extract_fences(path, text, errors)
+        fences.extend(file_fences)
+        prose = prose_without_code(text)
+
+        for pattern in BANNED:
+            for match in re.finditer(pattern, prose, re.IGNORECASE):
+                line = prose.count("\n", 0, match.start()) + 1
+                errors.append(
+                    f"{display(path)}:{line}: banned prose {match.group(0)!r}"
+                )
+
+        for british, american in BRITISH.items():
+            for match in re.finditer(rf"\b{british}\b", prose, re.IGNORECASE):
+                line = prose.count("\n", 0, match.start()) + 1
+                errors.append(
+                    f"{display(path)}:{line}: use American {american!r}, not {match.group(0)!r}"
+                )
+
+        for match in re.finditer(r"(?<!!)\[[^]]+\]\(([^)]+)\)", text):
+            validate_link(path, match.group(1), anchor_map, errors)
+
+        display_delimiters = [
+            number
+            for number, line in enumerate(text.splitlines(), 1)
+            if "$$" in line
+        ]
+        for number in display_delimiters:
+            if text.splitlines()[number - 1].strip() != "$$":
+                errors.append(
+                    f"{display(path)}:{number}: display-math delimiter must be on its own line"
+                )
+        if len(display_delimiters) % 2:
+            errors.append(f"{display(path)}: unbalanced display-math delimiters")
+
+        definitions = set(re.findall(r"^\[\^([^]]+)\]:", text, re.MULTILINE))
+        uses = set(re.findall(r"\[\^([^]]+)\]", re.sub(r"^\[\^[^]]+\]:.*$", "", text, flags=re.MULTILINE)))
+        for key in sorted(uses - definitions):
+            errors.append(f"{display(path)}: unresolved footnote citation [^{key}]")
+        for key in sorted(definitions - uses):
+            errors.append(f"{display(path)}: unused footnote citation [^{key}]")
+
+    for fence in fences:
+        validate_fence(fence, errors)
+
+    counts = collections.Counter(fence.language or "unlabeled" for fence in fences)
+    rust_count = counts.get("rust", 0)
+    if args.require_no_rust and rust_count:
+        errors.append(
+            f"{rust_count} Rust fences remain; move complete examples to the compiled harness "
+            "and mark genuinely schematic fragments as text"
+        )
+
+    citation_keys = set()
+    for text in texts.values():
+        citation_keys.update(re.findall(r"\[@([A-Za-z0-9_.:-]+)", text))
+
+    print(f"Markdown files: {len(markdown)}")
+    print("Fences: " + ", ".join(f"{lang}={count}" for lang, count in sorted(counts.items())))
+    print(f"Pandoc-style citation keys: {len(citation_keys)}")
+    print(f"Rust fences awaiting compile harness: {rust_count}")
+
+    if errors:
+        print(f"book check failed with {len(errors)} error(s):", file=sys.stderr)
+        for error in errors:
+            print(f"- {error}", file=sys.stderr)
+        return 1
+    print("book check passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_book_mermaid.mjs
+++ b/scripts/check_book_mermaid.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/** Parse every Mermaid fence with the exact browser bundle shipped by mdBook. */
+
+import { mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { JSDOM } from "jsdom";
+
+const root = resolve(dirname(new URL(import.meta.url).pathname), "..");
+const bookSource = join(root, "docs", "book", "src");
+const mermaidBundle = join(root, "docs", "book", "mermaid.min.js");
+
+function markdownFiles(directory) {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const path = join(directory, entry.name);
+    if (entry.isDirectory()) return markdownFiles(path);
+    return entry.isFile() && entry.name.endsWith(".md") ? [path] : [];
+  });
+}
+
+const assignment = "globalThis.mermaid = globalThis.__esbuild_esm_mermaid.default;";
+const replacement = "globalThis.mermaid = __esbuild_esm_mermaid.default;";
+const source = readFileSync(mermaidBundle, "utf8");
+if (!source.includes(assignment)) {
+  throw new Error(`unexpected Mermaid bundle wrapper in ${mermaidBundle}`);
+}
+
+const temporary = mkdtempSync(join(tmpdir(), "idiolect-mermaid-"));
+const modulePath = join(temporary, "mermaid.mjs");
+writeFileSync(
+  modulePath,
+  `${source.replace(assignment, replacement)}\nexport default globalThis.mermaid;\n`,
+);
+
+const dom = new JSDOM("<!doctype html><html><body></body></html>", {
+  url: "https://idiolect.test/",
+});
+for (const name of [
+  "document",
+  "Element",
+  "HTMLElement",
+  "SVGElement",
+  "Node",
+  "DOMParser",
+  "navigator",
+  "localStorage",
+]) {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value: dom.window[name],
+  });
+}
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: dom.window,
+});
+dom.window.SVGElement.prototype.getBBox = () => ({
+  height: 20,
+  width: 100,
+  x: 0,
+  y: 0,
+});
+dom.window.SVGElement.prototype.getComputedTextLength = () => 100;
+
+try {
+  const { default: mermaid } = await import(pathToFileURL(modulePath).href);
+
+  let count = 0;
+  const errors = [];
+  const fencePattern = /^```mermaid\s*\n([\s\S]*?)^```\s*$/gm;
+  for (const path of markdownFiles(bookSource).sort()) {
+    const markdown = readFileSync(path, "utf8");
+    for (const match of markdown.matchAll(fencePattern)) {
+      count += 1;
+      const line = markdown.slice(0, match.index).split("\n").length;
+      try {
+        await mermaid.parse(match[1], { suppressErrors: false });
+        const { svg } = await mermaid.render(`book-mermaid-${count}`, match[1]);
+        if (!svg.startsWith("<svg")) {
+          throw new Error("Mermaid renderer did not return an SVG document");
+        }
+        dom.window.document.body.replaceChildren();
+      } catch (error) {
+        errors.push(`${path.slice(root.length + 1)}:${line}: ${error}`);
+      }
+    }
+  }
+
+  process.stdout.write(`Mermaid fences: ${count}\n`);
+  if (errors.length > 0) {
+    for (const error of errors) process.stderr.write(`${error}\n`);
+    process.exitCode = 1;
+  } else {
+    process.stdout.write("Mermaid parsing and SVG rendering passed\n");
+  }
+} finally {
+  dom.window.close();
+  rmSync(temporary, { recursive: true, force: true });
+}

--- a/scripts/check_book_rust.py
+++ b/scripts/check_book_rust.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Compile every Rust fence in the mdBook as an independent binary."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from check_book import BOOK, ROOT, display, extract_fences
+
+
+def expand_include(fence_path: Path, body: str) -> str:
+    stripped = body.strip()
+    prefix = "{{#include "
+    if not (stripped.startswith(prefix) and stripped.endswith("}}")):
+        return body
+    include = stripped[len(prefix) : -2].strip()
+    source_name = include.split(":", 1)[0]
+    source = (fence_path.parent / source_name).resolve()
+    if not source.is_file():
+        raise ValueError(f"missing included Rust source {source}")
+    return source.read_text(encoding="utf-8")
+
+
+def runnable_source(body: str) -> str:
+    lines: list[str] = []
+    for line in body.splitlines():
+        if line.startswith("##"):
+            lines.append(line[1:])
+        elif line.startswith("# "):
+            lines.append(line[2:])
+        else:
+            lines.append(line)
+    source = "\n".join(lines).rstrip() + "\n"
+    if "fn main(" not in source:
+        source += "\nfn main() {}\n"
+    return source
+
+
+def main() -> int:
+    errors: list[str] = []
+    rust_fences = []
+    for path in sorted(BOOK.rglob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        rust_fences.extend(
+            fence
+            for fence in extract_fences(path.resolve(), text, errors)
+            if fence.language == "rust"
+        )
+    if errors:
+        for error in errors:
+            print(error, file=sys.stderr)
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="idiolect-book-rust-") as temporary:
+        project = Path(temporary)
+        bins = project / "src" / "bin"
+        bins.mkdir(parents=True)
+        mappings: list[str] = []
+        for number, fence in enumerate(rust_fences, 1):
+            name = f"book_{number:03d}"
+            try:
+                body = expand_include(fence.path, fence.body)
+            except ValueError as exc:
+                print(f"{display(fence.path)}:{fence.line}: {exc}", file=sys.stderr)
+                return 1
+            (bins / f"{name}.rs").write_text(runnable_source(body), encoding="utf-8")
+            mappings.append(f"{name}={display(fence.path)}:{fence.line}")
+
+        manifest = f'''[package]
+name = "idiolect-book-rust-check"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+anyhow = "1"
+async-trait = "0.1"
+serde = {{ version = "1", features = ["derive"] }}
+serde_json = "1"
+tokio = {{ version = "1", features = ["full"] }}
+tracing-subscriber = "0.3"
+url = "2"
+idiolect-codegen = {{ path = "{ROOT / 'crates/idiolect-codegen'}" }}
+idiolect-identity = {{ path = "{ROOT / 'crates/idiolect-identity'}", features = ["resolver-reqwest"] }}
+idiolect-indexer = {{ path = "{ROOT / 'crates/idiolect-indexer'}", features = ["firehose-tapped", "reconnecting", "resilience", "firehose-jetstream", "cursor-filesystem", "cursor-sqlite"] }}
+idiolect-lens = {{ path = "{ROOT / 'crates/idiolect-lens'}", features = ["pds-reqwest", "pds-resolve", "dpop-p256"] }}
+idiolect-migrate = {{ path = "{ROOT / 'crates/idiolect-migrate'}", features = ["cli"] }}
+idiolect-oauth = {{ path = "{ROOT / 'crates/idiolect-oauth'}", features = ["store-filesystem", "store-sqlite"] }}
+idiolect-observer = {{ path = "{ROOT / 'crates/idiolect-observer'}", features = ["daemon"] }}
+idiolect-orchestrator = {{ path = "{ROOT / 'crates/idiolect-orchestrator'}", features = ["daemon"] }}
+idiolect-records = {{ path = "{ROOT / 'crates/idiolect-records'}" }}
+idiolect-verify = {{ path = "{ROOT / 'crates/idiolect-verify'}" }}
+panproto-lens = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }}
+panproto-schema = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }}
+'''
+        (project / "Cargo.toml").write_text(manifest, encoding="utf-8")
+
+        print(f"Rust fences: {len(rust_fences)}")
+        for mapping in mappings:
+            print(mapping)
+        if not rust_fences:
+            print("Rust fence compilation passed (no runnable fences)")
+            return 0
+        completed = subprocess.run(
+            ["cargo", "check", "--quiet", "--bins", "--manifest-path", str(project / "Cargo.toml")],
+            cwd=ROOT,
+            check=False,
+        )
+        if completed.returncode:
+            print("Rust fence compilation failed; use the mapping above to locate each bin", file=sys.stderr)
+            return completed.returncode
+    print("Rust fence compilation passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/check_book_rust.py
+++ b/scripts/check_book_rust.py
@@ -93,8 +93,8 @@ idiolect-observer = {{ path = "{ROOT / 'crates/idiolect-observer'}", features = 
 idiolect-orchestrator = {{ path = "{ROOT / 'crates/idiolect-orchestrator'}", features = ["daemon"] }}
 idiolect-records = {{ path = "{ROOT / 'crates/idiolect-records'}" }}
 idiolect-verify = {{ path = "{ROOT / 'crates/idiolect-verify'}" }}
-panproto-lens = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }}
-panproto-schema = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }}
+panproto-lens = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }}
+panproto-schema = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }}
 '''
         (project / "Cargo.toml").write_text(manifest, encoding="utf-8")
 

--- a/scripts/publish-tutorial-lens/Cargo.lock
+++ b/scripts/publish-tutorial-lens/Cargo.lock
@@ -705,7 +705,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-lens"
-version = "0.8.0"
+version = "0.11.1"
 dependencies = [
  "idiolect-records",
  "panproto-inst",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.8.0"
+version = "0.11.1"
 dependencies = [
  "cid",
  "language-tags",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.8.0"
+version = "0.11.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1032,8 +1032,8 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-expr"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1042,8 +1042,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -1054,8 +1054,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -1070,8 +1070,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -1087,8 +1087,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -1102,8 +1102,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -1112,13 +1112,14 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
+ "smallvec 2.0.0-alpha.12",
  "thiserror",
 ]
 
 [[package]]
 name = "panproto-schema"
-version = "0.47.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.47.0#645542a1fd81a4cea278ea85bb52716fd6d64aee"
+version = "0.70.1"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
 dependencies = [
  "panproto-expr",
  "panproto-gat",

--- a/scripts/publish-tutorial-lens/Cargo.lock
+++ b/scripts/publish-tutorial-lens/Cargo.lock
@@ -1032,8 +1032,8 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-expr"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1042,8 +1042,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -1054,8 +1054,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -1070,8 +1070,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -1087,8 +1087,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -1097,13 +1097,14 @@ dependencies = [
  "panproto-schema",
  "rustc-hash",
  "serde",
+ "smallvec 2.0.0-alpha.12",
  "thiserror",
 ]
 
 [[package]]
 name = "panproto-protocols"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -1118,9 +1119,10 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.70.1"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.70.1#ee2f52d52e372e2ef771801d67c6b4469e165e1e"
+version = "0.71.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
 dependencies = [
+ "blake3",
  "panproto-expr",
  "panproto-gat",
  "rustc-hash",

--- a/scripts/publish-tutorial-lens/Cargo.lock
+++ b/scripts/publish-tutorial-lens/Cargo.lock
@@ -705,7 +705,7 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idiolect-lens"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "idiolect-records",
  "panproto-inst",
@@ -720,7 +720,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "cid",
  "language-tags",
@@ -733,7 +733,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/scripts/publish-tutorial-lens/Cargo.toml
+++ b/scripts/publish-tutorial-lens/Cargo.toml
@@ -37,5 +37,5 @@ tokio             = { version = "1", features = ["macros", "rt-multi-thread"] }
 idiolect-records  = { path = "../../crates/idiolect-records" }
 idiolect-lens     = { path = "../../crates/idiolect-lens", features = ["pds-reqwest"] }
 idiolect-verify   = { path = "../../crates/idiolect-verify" }
-panproto-lens     = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
-panproto-schema   = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-lens     = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-schema   = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }

--- a/scripts/publish-tutorial-lens/Cargo.toml
+++ b/scripts/publish-tutorial-lens/Cargo.toml
@@ -21,6 +21,10 @@ path = "src/verify.rs"
 name = "publish-tutorial-recommendation"
 path = "src/publish_recommendation.rs"
 
+[[bin]]
+name = "validate-tutorial-record"
+path = "src/validate.rs"
+
 [dependencies]
 anyhow            = "1"
 base64            = "0.22"
@@ -33,5 +37,5 @@ tokio             = { version = "1", features = ["macros", "rt-multi-thread"] }
 idiolect-records  = { path = "../../crates/idiolect-records" }
 idiolect-lens     = { path = "../../crates/idiolect-lens", features = ["pds-reqwest"] }
 idiolect-verify   = { path = "../../crates/idiolect-verify" }
-panproto-lens     = { git = "https://github.com/panproto/panproto.git", tag = "v0.47.0" }
-panproto-schema   = { git = "https://github.com/panproto/panproto.git", tag = "v0.47.0" }
+panproto-lens     = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }
+panproto-schema   = { git = "https://github.com/panproto/panproto.git", tag = "v0.70.1" }

--- a/scripts/publish-tutorial-lens/src/main.rs
+++ b/scripts/publish-tutorial-lens/src/main.rs
@@ -5,7 +5,7 @@
 //!   1. `dev.panproto.schema.schema/v1` — single-field "post:body"
 //!      with a string `text` child.
 //!   2. `dev.panproto.schema.schema/v2` — same shape with the kind
-//!      relabelled to `text` (derived from the chain's
+//!      relabeled to `text` (derived from the chain's
 //!      `target_schema`).
 //!   3. `dev.panproto.schema.lens/rename-sort-string-to-text` —
 //!      single-step protolens chain that applies a `rename_sort`.
@@ -167,7 +167,10 @@ async fn create_session(
     let url = format!("{pds}/xrpc/com.atproto.server.createSession");
     let resp = http
         .post(&url)
-        .json(&CreateSessionRequest { identifier, password })
+        .json(&CreateSessionRequest {
+            identifier,
+            password,
+        })
         .send()
         .await
         .context("createSession request")?;
@@ -275,9 +278,7 @@ fn format_rfc3339(secs: i64, millis: u32) -> String {
     let hour = (time_of_day / 3600) as u32;
     let minute = ((time_of_day % 3600) / 60) as u32;
     let second = (time_of_day % 60) as u32;
-    format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
-    )
+    format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z")
 }
 
 fn days_to_ymd(days: i64) -> (i64, u32, u32) {

--- a/scripts/publish-tutorial-lens/src/publish_recommendation.rs
+++ b/scripts/publish-tutorial-lens/src/publish_recommendation.rs
@@ -1,6 +1,5 @@
-//! Publishes a `dev.idiolect.recommendation` from the project DID
-//! endorsing the tutorial lens. Demonstrates the live publishing
-//! path tutorial 5 walks through.
+//! Publishes a tutorial community and its `dev.idiolect.recommendation`.
+//! The PDS assigns fresh record keys, so the example can be rerun.
 //!
 //! Auth: app-password Bearer mode. Reads three env vars (same set
 //! as the lens publisher):
@@ -14,15 +13,16 @@
 use std::env;
 
 use anyhow::{Context, Result, anyhow};
-use idiolect_records::Record;
 use idiolect_records::generated::dev::idiolect::defs::LensRef;
 use idiolect_records::generated::dev::idiolect::recommendation::{
     ConditionSourceIs, Recommendation, RecommendationConditions,
 };
+use idiolect_records::{Community, Record};
 use serde::{Deserialize, Serialize};
 
 const LENS_URI: &str = "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.lens/tutorial-rename-sort-string-to-text";
-const SRC_SCHEMA_URI: &str = "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.schema/tutorial-post-body-v1";
+const SRC_SCHEMA_URI: &str =
+    "at://did:plc:wdl4nnvxxdy4mc5vddxlm6f3/dev.panproto.schema.schema/tutorial-post-body-v1";
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -34,18 +34,28 @@ async fn main() -> Result<()> {
     let session = create_session(&http, &pds, &handle, &password).await?;
     eprintln!("logged in as {}", session.did);
 
-    // Issuing community is a placeholder for the tutorial — the
-    // canonical "idiolect" community record. The runtime doesn't
-    // dereference issuingCommunity at publish time, so the demo
-    // works even if the community record isn't on the network.
-    let community = format!("at://{}/dev.idiolect.community/canonical", session.did);
+    let community = Community {
+        appview_endpoint: None,
+        conventions: None,
+        conventions_text: None,
+        core_lenses: None,
+        core_schemas: None,
+        created_at: now()?,
+        description: "Community created by the idiolect publishing tutorial.".to_owned(),
+        endorsed_communities: None,
+        member_role_vocab: None,
+        members: Some(vec![session.did.parse()?]),
+        membership_roll: None,
+        name: "idiolect-tutorial".to_owned(),
+        record_hosting: None,
+        role_assignments: None,
+    };
+    let community_uri = publish(&http, &pds, &session.access_jwt, &session.did, &community).await?;
 
-    // Build the typed record. Conditions are postfix-operator
-    // trees over a closed combinator set; a single
-    // `conditionSourceIs` is the simplest "always applies to v1
-    // source records" predicate.
+    // A single `conditionSourceIs` limits this recommendation to
+    // records that use the tutorial's v1 source schema.
     let rec = Recommendation {
-        issuing_community: community.parse()?,
+        issuing_community: community_uri.parse()?,
         conditions: vec![RecommendationConditions::ConditionSourceIs(
             ConditionSourceIs {
                 schema: idiolect_records::generated::dev::idiolect::defs::SchemaRef {
@@ -75,19 +85,14 @@ async fn main() -> Result<()> {
         supersedes: None,
     };
 
-    let rkey = "tutorial-rename-sort";
-    publish(&http, &pds, &session.access_jwt, &session.did, &rec, rkey).await?;
-    println!(
-        "published at://{}/{}/{rkey}",
-        session.did,
-        Recommendation::NSID,
-    );
+    let recommendation_uri = publish(&http, &pds, &session.access_jwt, &session.did, &rec).await?;
+    println!("community      {community_uri}");
+    println!("recommendation {recommendation_uri}");
     Ok(())
 }
 
 // -----------------------------------------------------------------
-// session + publish (mirror of main.rs's helpers; small enough to
-// duplicate rather than factor out)
+// session + publish
 // -----------------------------------------------------------------
 
 #[derive(Serialize)]
@@ -112,7 +117,10 @@ async fn create_session(
     let url = format!("{pds}/xrpc/com.atproto.server.createSession");
     let resp = http
         .post(&url)
-        .json(&CreateSessionRequest { identifier, password })
+        .json(&CreateSessionRequest {
+            identifier,
+            password,
+        })
         .send()
         .await
         .context("createSession request")?;
@@ -130,23 +138,26 @@ async fn create_session(
 struct CreateRecordRequest<'a> {
     repo: &'a str,
     collection: &'a str,
-    rkey: &'a str,
     record: serde_json::Value,
 }
 
-async fn publish(
+#[derive(Deserialize)]
+struct CreateRecordResponse {
+    uri: String,
+}
+
+async fn publish<R: Record>(
     http: &reqwest::Client,
     pds: &str,
     bearer: &str,
     repo: &str,
-    rec: &Recommendation,
-    rkey: &str,
-) -> Result<()> {
+    rec: &R,
+) -> Result<String> {
     let mut value = serde_json::to_value(rec)?;
     if let serde_json::Value::Object(ref mut map) = value {
         map.insert(
             "$type".to_owned(),
-            serde_json::Value::String(Recommendation::NSID.to_owned()),
+            serde_json::Value::String(R::NSID.to_owned()),
         );
     }
     let url = format!("{pds}/xrpc/com.atproto.repo.createRecord");
@@ -155,8 +166,7 @@ async fn publish(
         .bearer_auth(bearer)
         .json(&CreateRecordRequest {
             repo,
-            collection: Recommendation::NSID,
-            rkey,
+            collection: R::NSID,
             record: value,
         })
         .send()
@@ -169,7 +179,7 @@ async fn publish(
             resp.text().await.unwrap_or_default()
         ));
     }
-    Ok(())
+    Ok(resp.json::<CreateRecordResponse>().await?.uri)
 }
 
 fn now() -> Result<idiolect_records::Datetime> {
@@ -185,9 +195,7 @@ fn now() -> Result<idiolect_records::Datetime> {
     let hour = (time_of_day / 3600) as u32;
     let minute = ((time_of_day % 3600) / 60) as u32;
     let second = (time_of_day % 60) as u32;
-    let s = format!(
-        "{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z"
-    );
+    let s = format!("{year:04}-{month:02}-{day:02}T{hour:02}:{minute:02}:{second:02}.{millis:03}Z");
     idiolect_records::Datetime::parse(s).map_err(|e| anyhow!("parse datetime: {e}"))
 }
 

--- a/scripts/publish-tutorial-lens/src/validate.rs
+++ b/scripts/publish-tutorial-lens/src/validate.rs
@@ -1,0 +1,30 @@
+//! Exercises runtime dispatch and validation for a bundled dialect record.
+
+use anyhow::{Result, bail};
+use idiolect_records::{AnyRecord, Dialect, Record, decode_record, examples};
+
+fn main() -> Result<()> {
+    let mut value = serde_json::to_value(examples::dialect())?;
+    let invalid = std::env::args().any(|arg| arg == "--invalid");
+
+    if invalid {
+        value
+            .as_object_mut()
+            .expect("a generated record serializes as an object")
+            .remove("createdAt");
+    }
+
+    match decode_record(&Dialect::nsid(), value) {
+        Ok(AnyRecord::Dialect(dialect)) if !invalid => {
+            println!("validated {}: {}", Dialect::NSID, dialect.name);
+        }
+        Err(error) if invalid => {
+            println!("rejected invalid {} record: {error}", Dialect::NSID);
+        }
+        Ok(_) if invalid => bail!("invalid record unexpectedly passed validation"),
+        Ok(other) => bail!("expected a dialect, got {}", other.nsid_str()),
+        Err(error) => return Err(error.into()),
+    }
+
+    Ok(())
+}

--- a/scripts/publish-tutorial-lens/src/verify.rs
+++ b/scripts/publish-tutorial-lens/src/verify.rs
@@ -6,9 +6,7 @@ use anyhow::Result;
 use idiolect_lens::{PdsResolver, PdsSchemaLoader, ReqwestPdsClient};
 use idiolect_records::Datetime;
 use idiolect_records::generated::dev::idiolect::defs::LensRef;
-use idiolect_verify::{
-    RoundtripTestRunner, VerificationRunner, VerificationTarget,
-};
+use idiolect_verify::{RoundtripTestRunner, VerificationRunner, VerificationTarget};
 use panproto_schema::Protocol;
 
 const PDS: &str = "https://jellybaby.us-east.host.bsky.network";


### PR DESCRIPTION
## Summary

Prepare idiolect 0.12.0 on Panproto 0.71.0, revise the full mdBook for technical accuracy and less generic prose, and add executable book-validation gates. Adapt symmetric view-only lens execution to Panproto's complement semantics and document that breaking contract explicitly.

## Change class

- [x] bug fix
- [ ] feature (non-breaking)
- [ ] refactor (no behavior change)
- [ ] documentation only
- [ ] release scaffolding / CI / build
- [ ] schema change (lexicon edit — will be classified by check-compat)

## Testing

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --all-targets --locked` (497 passed)
- `cargo test --workspace --locked --doc`
- `cargo deny check`
- Standalone tutorial: format, check, Clippy, and binary tests with the locked 0.71.0 dependencies
- `bun run typecheck`, `bun test` (36 passed), `bun run build`, and `bun run lint`
- `bun run generate:check` (36 Rust files, 36 TypeScript files, 28 Panproto schemas, and 15 fixtures match)
- Book source checker, isolated Rust-fence compilation, 12 Mermaid SVG renders, and `mdbook build`

## Architecture notes

Panproto 0.71.0 replaces low-level morphism enumeration with exact valued-CSP optimization and span certificates. Idiolect's `auto_generate` integration remains API-compatible, but alignment quality is now documented as a pair-relative ranking signal rather than a confidence score with a global threshold.

The view-only `apply_lens_symmetric` entry point cannot provide complement state from an earlier `get`. It now uses `put_without_complement`, accepts an isomorphic incoming leg, and returns a translation error when a lossy leg requires saved state. Callers that retain the complement must use Panproto's lower-level `SymmetricLens` operations.

The 11 vendored upstream `dev.panproto.*` Lexicons are byte-identical to Panproto commit `efa04235eb9aa9d718ad358b6104f69eac17881f`; only their provenance metadata changes. Local example records under `lexicons/dev/panproto/examples/` are now explicitly distinguished from that vendored subset.

## Checklist

- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass locally.
- [x] `cargo test --workspace` passes locally.
- [x] `bun run lint && bun run typecheck && bun run test` pass if the change touches TypeScript.
- [x] Generated sources are up-to-date (for lexicon / spec changes).
- [x] Relevant sections of `CHANGELOG.md` moved into the `[0.12.0]` release entry.

BREAKING CHANGE: `apply_lens_symmetric` now rejects a lossy incoming leg without complement state. Callers needing lossy symmetric translation must retain the complement from an earlier `get` and use Panproto's complement-aware `SymmetricLens` operations.
