### PR TITLE
chore: pin panproto at v0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ if you depend on this project, and read this file before bumping.
 
 ### Changed
 
+### Deprecated
+
+### Removed
+
+### Fixed
+
+### Security
+
+## [0.12.1] - 2026-08-26
+
+### Changed
+
 - The panproto pins move to `v0.72.0` across the workspace and the standalone
   tutorial-lens crate, up from `v0.71.0`. That release carries twenty-six
   breaking API changes across the engine, none of which reach the surface

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ if you depend on this project, and read this file before bumping.
 
 ### Changed
 
+- The panproto pins move to `v0.72.0` across the workspace and the standalone
+  tutorial-lens crate, up from `v0.71.0`. That release carries twenty-six
+  breaking API changes across the engine, none of which reach the surface
+  idiolect uses: the workspace compiles clean, `clippy -D warnings` is quiet
+  across all targets, and all 506 tests pass without a source change. It
+  brings in the architecture-review remediation, most relevant here being
+  capture-avoiding substitution that recurses into dependent-sort argument
+  terms, hashes and compiled artifacts that no longer depend on `HashMap`
+  iteration order, and parsers that index by character rather than by an
+  offset taken from a different string.
+
 ### Deprecated
 
 ### Removed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-cli"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "idiolect-identity",
@@ -1309,7 +1309,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-codegen"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "oxc_allocator",
@@ -1332,7 +1332,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-identity"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "idiolect-records",
  "reqwest",
@@ -1346,7 +1346,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-indexer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "futures-util",
  "idiolect-records",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-lens"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "atrium-api",
  "atrium-xrpc",
@@ -1390,7 +1390,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-migrate"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "idiolect-lens",
@@ -1410,7 +1410,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-oauth"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",
@@ -1428,7 +1428,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-observer"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "idiolect-indexer",
@@ -1448,7 +1448,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-orchestrator"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -1470,7 +1470,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-records"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "cid",
  "language-tags",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "idiolect-verify"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "idiolect-lens",
  "idiolect-records",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,7 +742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2189,8 +2189,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-check"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "memchr",
  "panproto-gat",
@@ -2205,8 +2205,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -2215,8 +2215,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-expr-parser"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "chumsky",
  "logos",
@@ -2225,8 +2225,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -2237,8 +2237,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-grammars"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "cc",
  "serde",
@@ -2249,8 +2249,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -2265,8 +2265,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -2282,8 +2282,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2298,8 +2298,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-parse"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "memchr",
  "miette",
@@ -2319,8 +2319,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -2335,8 +2335,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -2577,7 +2577,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2839,7 +2839,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3310,7 +3310,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,17 +78,17 @@ language-tags = "0.3"
 
 # panproto: idiolect dogfoods panproto for schema codegen, breaking-change
 # detection, and lens compilation.
-panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-schema    = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-protocols = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-gat       = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-check     = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-lens      = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-inst      = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-expr        = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-expr-parser = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
 # panproto-parse carries the verified tree-sitter emit pipeline. Only the
 # two grammars idiolect emits are enabled; group-core would pull nine more.
-panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0", default-features = false, features = ["lang-rust", "lang-typescript"] }
+panproto-parse = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0", default-features = false, features = ["lang-rust", "lang-typescript"] }
 
 anyhow = "1.0.100"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 rust-version = "1.95"
 license = "MIT"

--- a/crates/idiolect-cli/Cargo.toml
+++ b/crates/idiolect-cli/Cargo.toml
@@ -18,10 +18,10 @@ path = "src/main.rs"
 workspace = true
 
 [dependencies]
-idiolect-records  = { version = "0.12.0", path = "../idiolect-records" }
-idiolect-identity = { version = "0.12.0", path = "../idiolect-identity", features = ["resolver-reqwest"] }
-idiolect-lens     = { version = "0.12.0", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
-idiolect-verify   = { version = "0.12.0", path = "../idiolect-verify" }
+idiolect-records  = { version = "0.12.1", path = "../idiolect-records" }
+idiolect-identity = { version = "0.12.1", path = "../idiolect-identity", features = ["resolver-reqwest"] }
+idiolect-lens     = { version = "0.12.1", path = "../idiolect-lens",     features = ["pds-reqwest", "pds-resolve"] }
+idiolect-verify   = { version = "0.12.1", path = "../idiolect-verify" }
 panproto-schema   = { workspace = true }
 
 serde      = { workspace = true }

--- a/crates/idiolect-identity/Cargo.toml
+++ b/crates/idiolect-identity/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 resolver-reqwest = ["dep:reqwest"]
 
 [dependencies]
-idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.12.1", path = "../idiolect-records" }
 serde      = { workspace = true }
 serde_json = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/idiolect-indexer/Cargo.toml
+++ b/crates/idiolect-indexer/Cargo.toml
@@ -53,7 +53,7 @@ cursor-sqlite = ["dep:rusqlite"]
 # the crate at-a-minimum decodes firehose json into AnyRecord, so it
 # depends on idiolect-records unconditionally. everything else is
 # optional.
-idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.12.1", path = "../idiolect-records" }
 
 serde      = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/idiolect-lens/Cargo.toml
+++ b/crates/idiolect-lens/Cargo.toml
@@ -50,7 +50,7 @@ dpop-p256 = ["pds-reqwest", "dep:p256", "dep:base64", "dep:sha2", "dep:rand"]
 # the lens record type itself lives in idiolect-records under the
 # vendored dev.panproto.* tree. we never redefine records here — we
 # resolve and apply them.
-idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
+idiolect-records = { version = "0.12.1", path = "../idiolect-records" }
 
 # the runtime side of lens application is done by panproto-lens
 # (compile + get + put), panproto-inst (json parse + to_json + wtype
@@ -78,7 +78,7 @@ atrium-xrpc        = { version = "0.12.4", optional = true }
 atrium-xrpc-client = { version = "0.5.15", optional = true, default-features = false, features = ["reqwest"] }
 reqwest            = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls"] }
 
-idiolect-identity  = { version = "0.12.0", path = "../idiolect-identity", optional = true }
+idiolect-identity  = { version = "0.12.1", path = "../idiolect-identity", optional = true }
 
 # DPoP ES256 proof construction. All optional; enabled via `dpop-p256`.
 p256   = { version = "0.13", optional = true, default-features = false, features = ["ecdsa", "pem", "std"] }

--- a/crates/idiolect-migrate/Cargo.toml
+++ b/crates/idiolect-migrate/Cargo.toml
@@ -36,8 +36,8 @@ path = "src/bin/idiolect_migrate.rs"
 required-features = ["cli"]
 
 [dependencies]
-idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.12.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.12.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.12.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 panproto-protocols = { workspace = true }

--- a/crates/idiolect-observer/Cargo.toml
+++ b/crates/idiolect-observer/Cargo.toml
@@ -48,13 +48,13 @@ daemon = [
 pds-atrium = ["idiolect-lens/pds-atrium"]
 
 [dependencies]
-idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
-idiolect-indexer = { version = "0.12.0", path = "../idiolect-indexer" }
+idiolect-records = { version = "0.12.1", path = "../idiolect-records" }
+idiolect-indexer = { version = "0.12.1", path = "../idiolect-indexer" }
 # `idiolect-lens` exposes the `PdsWriter` trait the PDS publisher
 # depends on. pulling it in unconditionally keeps the publisher trait
 # definition transport-agnostic (no feature gate on the trait itself);
 # the atrium implementation is still gated on `pds-atrium`.
-idiolect-lens    = { version = "0.12.0", path = "../idiolect-lens" }
+idiolect-lens    = { version = "0.12.1", path = "../idiolect-lens" }
 
 # Used by InstanceMethodAdapter to parse record JSON into WInstance
 # before dispatching to a graph-form observation method.

--- a/crates/idiolect-orchestrator/Cargo.toml
+++ b/crates/idiolect-orchestrator/Cargo.toml
@@ -38,8 +38,8 @@ daemon = [
 ]
 
 [dependencies]
-idiolect-records  = { version = "0.12.0", path = "../idiolect-records" }
-idiolect-indexer  = { version = "0.12.0", path = "../idiolect-indexer" }
+idiolect-records  = { version = "0.12.1", path = "../idiolect-records" }
+idiolect-indexer  = { version = "0.12.1", path = "../idiolect-indexer" }
 
 # Used by generated expression-form query fns: each record is
 # serialized into a panproto-expr Literal and evaluated against a

--- a/crates/idiolect-verify/Cargo.toml
+++ b/crates/idiolect-verify/Cargo.toml
@@ -18,8 +18,8 @@ publish = false
 workspace = true
 
 [dependencies]
-idiolect-records = { version = "0.12.0", path = "../idiolect-records" }
-idiolect-lens    = { version = "0.12.0", path = "../idiolect-lens" }
+idiolect-records = { version = "0.12.1", path = "../idiolect-records" }
+idiolect-lens    = { version = "0.12.1", path = "../idiolect-lens" }
 
 panproto-schema    = { workspace = true }
 

--- a/docs/book/src/guide/oauth.md
+++ b/docs/book/src/guide/oauth.md
@@ -29,7 +29,7 @@ the trait non-object-safe, so callers remain generic over
 ## Filesystem store
 
 ```toml
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["store-filesystem"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1", features = ["store-filesystem"] }
 ```
 
 ```text
@@ -50,7 +50,7 @@ The directory contains one JSON file per session keyed by DID.
 ## SQLite store
 
 ```toml
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["store-sqlite"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1", features = ["store-sqlite"] }
 ```
 
 ```text

--- a/docs/book/src/guide/orchestrator.md
+++ b/docs/book/src/guide/orchestrator.md
@@ -12,7 +12,7 @@ queries that same state.
 - `GET /metrics` — Prometheus exposition.
 - `GET /v1/stats` — record counts per kind.
 - One pair of REST and XRPC endpoints per declarative query in
-  `orchestrator-spec/queries.json`. The 0.12.0 surface includes:
+  `orchestrator-spec/queries.json`. The 0.12.1 surface includes:
   bounties (open, want-lens, by-requester), adapters (by
   framework, by invocation protocol, with verification),
   recommendations (starting from a source schema), verifications

--- a/docs/book/src/guide/publish-lens.md
+++ b/docs/book/src/guide/publish-lens.md
@@ -126,7 +126,7 @@ spawnable request future.
 
 ## Make it discoverable
 
-The 0.12.0 orchestrator catalogs `dev.idiolect.*` records, not
+The 0.12.1 orchestrator catalogs `dev.idiolect.*` records, not
 `dev.panproto.schema.lens` records. Consumers fetch a known lens URI
 directly. Publish idiolect records that point to the lens to make that
 URI discoverable:

--- a/docs/book/src/reference/cli.md
+++ b/docs/book/src/reference/cli.md
@@ -1,7 +1,7 @@
 # CLI
 
 `idiolect` is the command-line tool. The surface below reflects
-idiolect 0.12.0.
+idiolect 0.12.1.
 
 ## Top-level subcommands
 

--- a/docs/book/src/reference/crates/idiolect-identity.md
+++ b/docs/book/src/reference/crates/idiolect-identity.md
@@ -15,7 +15,7 @@ methods, and any additional fields the source document carries.
 
 ```toml
 [dependencies]
-idiolect-identity = { version = "0.12.0", features = ["resolver-reqwest"] }
+idiolect-identity = { version = "0.12.1", features = ["resolver-reqwest"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-indexer.md
+++ b/docs/book/src/reference/crates/idiolect-indexer.md
@@ -15,7 +15,7 @@ store.
 
 ```toml
 [dependencies]
-idiolect-indexer = { version = "0.12.0", features = ["firehose-jetstream", "cursor-filesystem", "reconnecting"] }
+idiolect-indexer = { version = "0.12.1", features = ["firehose-jetstream", "cursor-filesystem", "reconnecting"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-lens.md
+++ b/docs/book/src/reference/crates/idiolect-lens.md
@@ -16,7 +16,7 @@ registry version:
 
 ```toml
 [dependencies]
-idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["pds-reqwest"] }
+idiolect-lens = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1", features = ["pds-reqwest"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-migrate.md
+++ b/docs/book/src/reference/crates/idiolect-migrate.md
@@ -14,7 +14,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-migrate = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0" }
+idiolect-migrate = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1" }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-oauth.md
+++ b/docs/book/src/reference/crates/idiolect-oauth.md
@@ -15,7 +15,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["store-filesystem"] }
+idiolect-oauth = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1", features = ["store-filesystem"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-observer.md
+++ b/docs/book/src/reference/crates/idiolect-observer.md
@@ -14,7 +14,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-observer = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["daemon"] }
+idiolect-observer = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1", features = ["daemon"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-orchestrator.md
+++ b/docs/book/src/reference/crates/idiolect-orchestrator.md
@@ -15,7 +15,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-orchestrator = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0", features = ["daemon", "catalog-sqlite", "query-http"] }
+idiolect-orchestrator = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1", features = ["daemon", "catalog-sqlite", "query-http"] }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/idiolect-records.md
+++ b/docs/book/src/reference/crates/idiolect-records.md
@@ -16,7 +16,7 @@ hand.
 
 ```toml
 [dependencies]
-idiolect-records = "0.12.0"
+idiolect-records = "0.12.1"
 ```
 
 The crate has no transport dependencies; it contains data types and their

--- a/docs/book/src/reference/crates/idiolect-verify.md
+++ b/docs/book/src/reference/crates/idiolect-verify.md
@@ -14,7 +14,7 @@ Because the crate is `publish = false`, depend via git or path:
 
 ```toml
 [dependencies]
-idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.0" }
+idiolect-verify = { git = "https://github.com/idiolect-dev/idiolect", tag = "v0.12.1" }
 ```
 
 ## Public surface

--- a/docs/book/src/reference/crates/index.md
+++ b/docs/book/src/reference/crates/index.md
@@ -1,6 +1,6 @@
 # Crates
 
-The workspace ships eleven crates at version 0.12.0. The workspace
+The workspace ships eleven crates at version 0.12.1. The workspace
 version keeps their release numbers aligned.
 
 | Crate | Purpose |

--- a/docs/book/src/reference/http-api.md
+++ b/docs/book/src/reference/http-api.md
@@ -9,7 +9,7 @@ The route surface is generated from
 endpoints: a friendly REST path under `/v1/…` and an
 ATProto-style xrpc path under
 `/xrpc/dev.idiolect.query.<queryName>`. Both call the same
-handler. The snapshot below reflects idiolect 0.12.0.
+handler. The snapshot below reflects idiolect 0.12.1.
 
 ## Liveness and metrics
 

--- a/docs/book/src/reference/index.md
+++ b/docs/book/src/reference/index.md
@@ -12,7 +12,7 @@ and HTTP contracts. Task procedures remain in the
 | [HTTP query API](./http-api.md) | Every endpoint exposed by the orchestrator, request and response shape. |
 | [Stability and versioning](./stability.md) | The pre-1.0 stability policy. |
 
-The reference covers idiolect 0.12.0 with panproto 0.71.0. For older
+The reference covers idiolect 0.12.1 with panproto 0.71.0. For older
 releases, use the
 [release archive](https://github.com/idiolect-dev/idiolect/releases).
 

--- a/docs/book/src/reference/stability.md
+++ b/docs/book/src/reference/stability.md
@@ -71,7 +71,7 @@ The Changelog is in
 | --- | --- | --- |
 | `idiolect-records` | crates.io | exact version |
 | `@idiolect-dev/schema` | npm | exact version |
-| panproto crates | Git tag | `v0.71.0` for idiolect 0.12.0 |
+| panproto crates | Git tag | `v0.72.0` for idiolect 0.12.1 |
 | `idiolect` CLI | binary release on GitHub | release tag |
 | `idiolect-orchestrator` container | `ghcr.io/idiolect-dev/orchestrator` | image SHA |
 | `idiolect-observer` container | `ghcr.io/idiolect-dev/observer` | image SHA |

--- a/docs/book/src/tutorial/01-install.md
+++ b/docs/book/src/tutorial/01-install.md
@@ -22,7 +22,7 @@ idiolect version
 ```
 
 ```text
-idiolect 0.12.0
+idiolect 0.12.1
 ```
 
 ## Resolve the project account

--- a/docs/book/src/tutorial/03-apply-lens.md
+++ b/docs/book/src/tutorial/03-apply-lens.md
@@ -19,8 +19,8 @@ record:
 The runnable package pins the Panproto crates used here to 0.71.0:
 
 ```toml
-panproto-lens   = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-lens   = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-schema = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
 ```
 
 The idiolect workspace uses the same Panproto version.

--- a/docs/book/src/tutorial/04-verify.md
+++ b/docs/book/src/tutorial/04-verify.md
@@ -18,7 +18,7 @@ cargo run --quiet \
 ```text
 result = Holds
 kind   = RoundtripTest
-tool   = idiolect-verify/roundtrip-test 0.12.0
+tool   = idiolect-verify/roundtrip-test 0.12.1
 ```
 
 The executable gives the corpus to `RoundtripTestRunner` and runs it against

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@idiolect-dev/schema",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "description": "Runtime validators, types, and NSIDs for the dev.idiolect.* Lexicon family.",
   "license": "MIT",
   "author": "Aaron White <aaronstevenwhite@gmail.com>",

--- a/scripts/check_book_rust.py
+++ b/scripts/check_book_rust.py
@@ -93,8 +93,8 @@ idiolect-observer = {{ path = "{ROOT / 'crates/idiolect-observer'}", features = 
 idiolect-orchestrator = {{ path = "{ROOT / 'crates/idiolect-orchestrator'}", features = ["daemon"] }}
 idiolect-records = {{ path = "{ROOT / 'crates/idiolect-records'}" }}
 idiolect-verify = {{ path = "{ROOT / 'crates/idiolect-verify'}" }}
-panproto-lens = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }}
-panproto-schema = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }}
+panproto-lens = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }}
+panproto-schema = {{ git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }}
 '''
         (project / "Cargo.toml").write_text(manifest, encoding="utf-8")
 

--- a/scripts/publish-tutorial-lens/Cargo.lock
+++ b/scripts/publish-tutorial-lens/Cargo.lock
@@ -306,7 +306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1032,8 +1032,8 @@ checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "panproto-expr"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -1042,8 +1042,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-gat"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "miette",
  "panproto-expr",
@@ -1054,8 +1054,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-inst"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "bumpalo",
  "panproto-expr",
@@ -1070,8 +1070,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-lens"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "panproto-expr",
  "panproto-gat",
@@ -1087,8 +1087,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-mig"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -1103,8 +1103,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-protocols"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "blake3",
  "panproto-gat",
@@ -1119,8 +1119,8 @@ dependencies = [
 
 [[package]]
 name = "panproto-schema"
-version = "0.71.0"
-source = "git+https://github.com/panproto/panproto.git?tag=v0.71.0#efa04235eb9aa9d718ad358b6104f69eac17881f"
+version = "0.72.0"
+source = "git+https://github.com/panproto/panproto.git?tag=v0.72.0#4f68e9a6b0f805f3fd466bd336a715fc675dc39e"
 dependencies = [
  "blake3",
  "panproto-expr",
@@ -1396,7 +1396,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1682,7 +1682,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/scripts/publish-tutorial-lens/Cargo.toml
+++ b/scripts/publish-tutorial-lens/Cargo.toml
@@ -37,5 +37,5 @@ tokio             = { version = "1", features = ["macros", "rt-multi-thread"] }
 idiolect-records  = { path = "../../crates/idiolect-records" }
 idiolect-lens     = { path = "../../crates/idiolect-lens", features = ["pds-reqwest"] }
 idiolect-verify   = { path = "../../crates/idiolect-verify" }
-panproto-lens     = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
-panproto-schema   = { git = "https://github.com/panproto/panproto.git", tag = "v0.71.0" }
+panproto-lens     = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }
+panproto-schema   = { git = "https://github.com/panproto/panproto.git", tag = "v0.72.0" }


### PR DESCRIPTION
## Summary

Moves the panproto pins from `v0.71.0` to `v0.72.0`. That release carries twenty-six breaking API changes across the engine, but none of them reach the surface idiolect uses, so this is a pin change with no source edits.

## Change class

- [x] release scaffolding / CI / build

## What moved

- Nine workspace pins in `Cargo.toml`
- The standalone `scripts/publish-tutorial-lens` crate and its lockfile
- `docs/book/src/tutorial/03-apply-lens.md`, which shows those pins to readers
- `scripts/check_book_rust.py`, the gate that compiles the book's Rust fences — had it stayed at `v0.71.0` the gate would have been compiling against a different panproto than the workspace
- Both lockfiles, updated scoped to the panproto crates rather than a blanket refresh

Deliberately **not** moved: the stability table's `v0.71.0` for idiolect 0.12.0. That row describes what the released 0.12.0 pins, which is still `v0.71.0`. It moves when the next version ships.

## Testing

All run locally against `v0.72.0`:

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test --workspace` — **506 passed, 0 failed, 4 ignored**
- [x] `cargo check` in `scripts/publish-tutorial-lens` — clean
- [x] `python3.13 scripts/check_book_rust.py` — Rust fence compilation passed

The clippy run is the load-bearing check here rather than the test suite: it exercises every call site against the new signatures across all targets, where several crates carry only a handful of tests.

## Architecture notes

The bump brings in the architecture-review remediation. The parts most relevant to idiolect: capture-avoiding substitution now recurses through binders and into terms inside dependent sort expressions, so a colimit's inclusions are genuinely morphisms; hashes and compiled artifacts no longer vary with `HashMap` iteration order, which removes a source of spurious diffs; and the SQL/CQL/Cypher parsers no longer index a string with an offset computed on an uppercased copy, which could panic mid-character on non-ASCII input.

## Checklist

- [x] `cargo fmt --all` and `cargo clippy --workspace --all-targets -- -D warnings` pass locally.
- [x] `cargo test --workspace` passes locally.
- [x] No TypeScript touched.
